### PR TITLE
Serialize arrays and maps with known length

### DIFF
--- a/src/serialize/dataclass.rs
+++ b/src/serialize/dataclass.rs
@@ -47,6 +47,7 @@ impl<'p> Serialize for DataclassFastSerializer {
         if unlikely!(len == 0) {
             return serializer.serialize_map(Some(0)).unwrap().end();
         }
+        // length is unknown without further work because attributes are filtered below
         let mut map = serializer.serialize_map(None).unwrap();
         let mut pos = 0isize;
         let mut str_size: pyo3::ffi::Py_ssize_t = 0;
@@ -128,6 +129,7 @@ impl<'p> Serialize for DataclassFallbackSerializer {
         if unlikely!(len == 0) {
             return serializer.serialize_map(Some(0)).unwrap().end();
         }
+        // length is unknown without further work because attributes are filtered below
         let mut map = serializer.serialize_map(None).unwrap();
         let mut pos = 0isize;
         let mut str_size: pyo3::ffi::Py_ssize_t = 0;

--- a/src/serialize/dict.rs
+++ b/src/serialize/dict.rs
@@ -79,12 +79,13 @@ impl<'p> Serialize for Dict {
     where
         S: Serializer,
     {
-        let mut map = serializer.serialize_map(None).unwrap();
+        let len = unsafe { PyDict_GET_SIZE(self.ptr) as usize };
+        let mut map = serializer.serialize_map(Some(len)).unwrap();
         let mut pos = 0isize;
         let mut str_size: pyo3::ffi::Py_ssize_t = 0;
         let mut key: *mut pyo3::ffi::PyObject = std::ptr::null_mut();
         let mut value: *mut pyo3::ffi::PyObject = std::ptr::null_mut();
-        for _ in 0..=unsafe { PyDict_GET_SIZE(self.ptr) as usize } - 1 {
+        for _ in 0..=len - 1 {
             unsafe {
                 pyo3::ffi::_PyDict_Next(
                     self.ptr,

--- a/src/serialize/list.rs
+++ b/src/serialize/list.rs
@@ -37,12 +37,10 @@ impl<'p> Serialize for ListSerializer {
     where
         S: Serializer,
     {
-        let mut seq = serializer.serialize_seq(None).unwrap();
+        let len = ffi!(PyList_GET_SIZE(self.ptr)) as usize;
+        let mut seq = serializer.serialize_seq(Some(len)).unwrap();
         let slice: &[*mut pyo3::ffi::PyObject] = unsafe {
-            std::slice::from_raw_parts(
-                (*(self.ptr as *mut pyo3::ffi::PyListObject)).ob_item,
-                ffi!(PyList_GET_SIZE(self.ptr)) as usize,
-            )
+            std::slice::from_raw_parts((*(self.ptr as *mut pyo3::ffi::PyListObject)).ob_item, len)
         };
         for &each in slice {
             let value = PyObjectSerializer::new(

--- a/src/serialize/numpy.rs
+++ b/src/serialize/numpy.rs
@@ -218,75 +218,76 @@ impl<'p> Serialize for NumpyArray {
     where
         S: Serializer,
     {
-        let mut seq = serializer.serialize_seq(None).unwrap();
-
-        if self.depth >= self.shape().len() || self.shape()[self.depth] != 0 {
-            if !self.children.is_empty() {
-                for child in &self.children {
-                    seq.serialize_element(child).unwrap();
+        if !(self.depth >= self.shape().len() || self.shape()[self.depth] != 0) {
+            serializer.serialize_seq(Some(0)).unwrap().end()
+        } else if !self.children.is_empty() {
+            let mut seq = serializer.serialize_seq(Some(self.children.len())).unwrap();
+            for child in &self.children {
+                seq.serialize_element(child).unwrap();
+            }
+            seq.end()
+        } else {
+            let data_ptr = self.data();
+            let num_items = self.num_items();
+            let mut seq = serializer.serialize_seq(Some(num_items)).unwrap();
+            match self.kind {
+                ItemType::F64 => {
+                    let slice: &[f64] = slice!(data_ptr as *const f64, num_items);
+                    for &each in slice.iter() {
+                        seq.serialize_element(&DataTypeF64 { obj: each }).unwrap();
+                    }
                 }
-            } else {
-                let data_ptr = self.data();
-                let num_items = self.num_items();
-                match self.kind {
-                    ItemType::F64 => {
-                        let slice: &[f64] = slice!(data_ptr as *const f64, num_items);
-                        for &each in slice.iter() {
-                            seq.serialize_element(&DataTypeF64 { obj: each }).unwrap();
-                        }
+                ItemType::F32 => {
+                    let slice: &[f32] = slice!(data_ptr as *const f32, num_items);
+                    for &each in slice.iter() {
+                        seq.serialize_element(&DataTypeF32 { obj: each }).unwrap();
                     }
-                    ItemType::F32 => {
-                        let slice: &[f32] = slice!(data_ptr as *const f32, num_items);
-                        for &each in slice.iter() {
-                            seq.serialize_element(&DataTypeF32 { obj: each }).unwrap();
-                        }
+                }
+                ItemType::I64 => {
+                    let slice: &[i64] = slice!(data_ptr as *const i64, num_items);
+                    for &each in slice.iter() {
+                        seq.serialize_element(&DataTypeI64 { obj: each }).unwrap();
                     }
-                    ItemType::I64 => {
-                        let slice: &[i64] = slice!(data_ptr as *const i64, num_items);
-                        for &each in slice.iter() {
-                            seq.serialize_element(&DataTypeI64 { obj: each }).unwrap();
-                        }
+                }
+                ItemType::I32 => {
+                    let slice: &[i32] = slice!(data_ptr as *const i32, num_items);
+                    for &each in slice.iter() {
+                        seq.serialize_element(&DataTypeI32 { obj: each }).unwrap();
                     }
-                    ItemType::I32 => {
-                        let slice: &[i32] = slice!(data_ptr as *const i32, num_items);
-                        for &each in slice.iter() {
-                            seq.serialize_element(&DataTypeI32 { obj: each }).unwrap();
-                        }
+                }
+                ItemType::I8 => {
+                    let slice: &[i8] = slice!(data_ptr as *const i8, num_items);
+                    for &each in slice.iter() {
+                        seq.serialize_element(&DataTypeI8 { obj: each }).unwrap();
                     }
-                    ItemType::I8 => {
-                        let slice: &[i8] = slice!(data_ptr as *const i8, num_items);
-                        for &each in slice.iter() {
-                            seq.serialize_element(&DataTypeI8 { obj: each }).unwrap();
-                        }
+                }
+                ItemType::U8 => {
+                    let slice: &[u8] = slice!(data_ptr as *const u8, num_items);
+                    for &each in slice.iter() {
+                        seq.serialize_element(&DataTypeU8 { obj: each }).unwrap();
                     }
-                    ItemType::U8 => {
-                        let slice: &[u8] = slice!(data_ptr as *const u8, num_items);
-                        for &each in slice.iter() {
-                            seq.serialize_element(&DataTypeU8 { obj: each }).unwrap();
-                        }
+                }
+                ItemType::U32 => {
+                    let slice: &[u32] = slice!(data_ptr as *const u32, num_items);
+                    for &each in slice.iter() {
+                        seq.serialize_element(&DataTypeU32 { obj: each }).unwrap();
                     }
-                    ItemType::U32 => {
-                        let slice: &[u32] = slice!(data_ptr as *const u32, num_items);
-                        for &each in slice.iter() {
-                            seq.serialize_element(&DataTypeU32 { obj: each }).unwrap();
-                        }
+                }
+                ItemType::U64 => {
+                    let slice: &[u64] = slice!(data_ptr as *const u64, num_items);
+                    for &each in slice.iter() {
+                        seq.serialize_element(&DataTypeU64 { obj: each }).unwrap();
                     }
-                    ItemType::U64 => {
-                        let slice: &[u64] = slice!(data_ptr as *const u64, num_items);
-                        for &each in slice.iter() {
-                            seq.serialize_element(&DataTypeU64 { obj: each }).unwrap();
-                        }
-                    }
-                    ItemType::BOOL => {
-                        let slice: &[u8] = slice!(data_ptr as *const u8, num_items);
-                        for &each in slice.iter() {
-                            seq.serialize_element(&DataTypeBOOL { obj: each }).unwrap();
-                        }
+                }
+                ItemType::BOOL => {
+                    let slice: &[u8] = slice!(data_ptr as *const u8, num_items);
+                    for &each in slice.iter() {
+                        seq.serialize_element(&DataTypeBOOL { obj: each }).unwrap();
                     }
                 }
             }
+            seq.end()
         }
-        seq.end()
     }
 }
 

--- a/src/serialize/tuple.rs
+++ b/src/serialize/tuple.rs
@@ -38,16 +38,19 @@ impl<'p> Serialize for TupleSerializer {
     where
         S: Serializer,
     {
-        let mut seq = serializer.serialize_seq(None).unwrap();
-        for i in 0..=ffi!(PyTuple_GET_SIZE(self.ptr)) - 1 {
-            let elem = nonnull!(ffi!(PyTuple_GET_ITEM(self.ptr, i as isize)));
-            seq.serialize_element(&PyObjectSerializer::new(
-                elem.as_ptr(),
-                self.opts,
-                self.default_calls,
-                self.recursion + 1,
-                self.default,
-            ))?
+        let len = ffi!(PyTuple_GET_SIZE(self.ptr)) as usize;
+        let mut seq = serializer.serialize_seq(Some(len)).unwrap();
+        if len > 0 {
+            for i in 0..=len - 1 {
+                let elem = nonnull!(ffi!(PyTuple_GET_ITEM(self.ptr, i as isize)));
+                seq.serialize_element(&PyObjectSerializer::new(
+                    elem.as_ptr(),
+                    self.opts,
+                    self.default_calls,
+                    self.recursion + 1,
+                    self.default,
+                ))?
+            }
         }
         seq.end()
     }


### PR DESCRIPTION
This is benchmark.sh for a few fixtures, before left and after
right, in operations per second:

	canada packb:       423,  978
	citm_catalog packb: 1064, 1839
	github packb:       2533, 5007
	numpy float64:      20,   41
	twitter packb:      2620, 4463