### PR TITLE
Updated README to include new options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 ## Next Version
+### Misc
+- Updated README to include new options. by [@ThomasTNO](https://github.com/aviramha/ormsgpack/pull/70)
 ## 1.1.0 - 8/1/2022
 ### Added
 - Add optional passthrough for tuples. by [@TariqTNO](https://github.com/aviramha/ormsgpack/pull/64)

--- a/README.md
+++ b/README.md
@@ -245,6 +245,26 @@ Do not serialize the `microsecond` field on `datetime.datetime` and
     )
 ```
 
+##### OPT_PASSTHROUGH_BIG_INT
+
+Enables passthrough of big (Python) ints. By setting this option, one can set a `default` function for ints larger than 63 bits, smaller ints are still serialized efficiently.
+
+```python
+>>> import ormsgpack
+>>> ormsgpack.packb(
+        2**65,
+    )
+TypeError: Integer exceeds 64-bit range
+>>> ormsgpack.unpackb(
+        ormsgpack.packb(
+            2**65,
+            option=ormsgpack.OPT_PASSTHROUGH_BIG_INT,
+            default=lambda _: {"type": "bigint", "value": str(_) }
+        )
+    )
+{'type': 'bigint', 'value': '36893488147419103232'}
+```
+
 ##### OPT_PASSTHROUGH_DATACLASS
 
 Passthrough `dataclasses.dataclass` instances to `default`. This allows
@@ -330,6 +350,28 @@ b'\xa6******'
 
 This does not affect serializing subclasses as `dict` keys if using
 OPT_NON_STR_KEYS.
+
+##### OPT_PASSTHROUGH_TUPLE
+
+Passthrough tuples to `default`.
+
+```python
+>>> import ormsgpack
+>>> ormsgpack.unpackb(
+        ormsgpack.packb(
+            (9193, "test", 42),
+        )
+    )
+[9193, 'test', 42]
+>>> ormsgpack.unpackb(
+        ormsgpack.packb(
+            (9193, "test", 42),
+            option=ormsgpack.OPT_PASSTHROUGH_TUPLE,
+            default=lambda _: {"type": "tuple", "value": list(_)}
+        )
+    )
+{'type': 'tuple', 'value': [9193, 'test', 42]}
+```
 
 ##### OPT_SERIALIZE_NUMPY
 


### PR DESCRIPTION
I found out that README did not include the new options introduced in 1.1.0.

This PR resolves the issue.