### PR TITLE
Fix: Drop python 3.6 and support 3.11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - run: .venv/bin/pip install -U pip wheel
       - run: .venv/bin/pip install -U twine maturin
       - run: .venv/bin/pip install -r requirements.txt
-      - run: .venv/bin/maturin build --no-sdist --release --strip --manylinux 2014 -i /opt/python/${{ matrix.python-path }}/bin/python --target x86_64-unknown-linux-gnu
+      - run: .venv/bin/maturin build --release --strip --manylinux 2014 -i /opt/python/${{ matrix.python-path }}/bin/python --target x86_64-unknown-linux-gnu
       - run: .venv/bin/pip install ormsgpack --no-index -f target/wheels
       - run: .venv/bin/pytest
       - run: .venv/bin/twine upload --non-interactive --skip-existing target/wheels/*
@@ -59,7 +59,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: pip install --user -U pip wheel twine maturin
       - run: pip install -r requirements.txt
-      - run: maturin build --no-sdist --release --strip -i $pythonLocation"python.exe"
+      - run: maturin build --release --strip -i $pythonLocation"python.exe"
       - run: pip install ormsgpack --no-index -f target/wheels
       - run: pytest
       - run: twine upload --non-interactive --skip-existing target\wheels\*
@@ -87,7 +87,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: pip install -U pip wheel twine maturin
       - run: pip install -r requirements.txt
-      - run: maturin build --no-sdist --release --strip --manylinux off -i $pythonLocation/python --target x86_64-apple-darwin
+      - run: maturin build --release --strip --manylinux off -i $pythonLocation/python --target x86_64-apple-darwin
       - run: pip install ormsgpack --no-index -f target/wheels
       - run: pytest
       - run: twine upload --non-interactive --skip-existing target/wheels/*
@@ -114,7 +114,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install -U pip wheel twine maturin
-      - run: PATH=$HOME/.cargo/bin:$PATH PYO3_CROSS_LIB_DIR=$(python -c "import sysconfig;print(sysconfig.get_config_var('LIBDIR'))") maturin build --no-sdist --release --strip --cargo-extra-args="--features=unstable-simd" --universal2
+      - run: PATH=$HOME/.cargo/bin:$PATH PYO3_CROSS_LIB_DIR=$(python -c "import sysconfig;print(sysconfig.get_config_var('LIBDIR'))") maturin build --release --strip --cargo-extra-args="--features=unstable-simd" --universal2
       - run: twine upload --non-interactive --skip-existing target/wheels/*
   release_sdist:
     name: Release sdist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install --user -U pip wheel twine maturin
+      - run: python -m pip install --user -U pip wheel twine maturin
       - run: pip install -r requirements.txt
       - run: maturin build --release --strip -i $pythonLocation"python.exe"
       - run: pip install ormsgpack --no-index -f target/wheels
@@ -85,7 +85,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install -U pip wheel twine maturin
+      - run: python -m pip install -U pip wheel twine maturin
       - run: pip install -r requirements.txt
       - run: maturin build --release --strip --manylinux off -i $pythonLocation/python --target x86_64-apple-darwin
       - run: pip install ormsgpack --no-index -f target/wheels
@@ -113,7 +113,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install -U pip wheel twine maturin
+      - run: python -m pip install -U pip wheel twine maturin
       - run: PATH=$HOME/.cargo/bin:$PATH PYO3_CROSS_LIB_DIR=$(python -c "import sysconfig;print(sysconfig.get_config_var('LIBDIR'))") maturin build --release --strip --cargo-extra-args="--features=unstable-simd" --universal2
       - run: twine upload --non-interactive --skip-existing target/wheels/*
   release_sdist:
@@ -133,7 +133,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - run: pip install -U pip wheel twine maturin
+      - run: python -m pip install -U pip wheel twine maturin
       - run: pip install -r requirements.txt
       - run: maturin sdist
       - run: twine upload --non-interactive --skip-existing target/wheels/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-path: ['cp37-cp37m', 'cp38-cp38', 'cp39-cp39', 'cp310-cp310']
+        python-path: ['cp37-cp37m', 'cp38-cp38', 'cp39-cp39', 'cp310-cp310', 'cp311-cp311']
     container: quay.io/pypa/manylinux2014_x86_64:latest
     env:
       TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}
@@ -41,7 +41,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     env:
       TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}
       TWINE_USERNAME: ${{secrets.TWINE_USERNAME}}
@@ -68,7 +68,7 @@ jobs:
     name: Release macOS (x86_64)
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     runs-on: macos-latest
     env:
       TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}
@@ -96,7 +96,7 @@ jobs:
     name: Release macOS (universal)
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     runs-on: macos-latest
     env:
       TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install --user -U pip wheel
+      - run: python -m pip install --user -U pip wheel
       - run: pip install -r requirements.txt
       - run: maturin build --release --strip --manylinux off -i $pythonLocation/python
         if: ${{ runner.os != 'Windows' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: pip install --user -U pip wheel
       - run: pip install -r requirements.txt
-      - run: maturin build --no-sdist --release --strip --manylinux off -i $pythonLocation/python
+      - run: maturin build --release --strip --manylinux off -i $pythonLocation/python
         if: ${{ runner.os != 'Windows' }}
-      - run: maturin build --no-sdist --release --strip --manylinux off -i $pythonLocation"python.exe"
+      - run: maturin build --release --strip --manylinux off -i $pythonLocation"python.exe"
         if: ${{ runner.os == 'Windows' }}
       - run: pip install ormsgpack --no-index -f target/wheels
       - run: pytest tests/

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ vendor
 build
 !json/perfect_float.patch
 .DS_Store
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
@@ -108,6 +108,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "ormsgpack"
@@ -184,12 +193,13 @@ checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
 name = "pyo3"
-version = "0.16.5"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6302e85060011447471887705bb7838f14aba43fcb06957d823739a496b3dc"
+checksum = "268be0c73583c183f2b14052337465768c07726936a260f480f0857cb95ba543"
 dependencies = [
  "cfg-if",
  "libc",
+ "memoffset",
  "parking_lot",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -197,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.16.5"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b65b546c35d8a3b1b2f0ddbac7c6a569d759f357f2b9df884f5d6b719152c8"
+checksum = "28fcd1e73f06ec85bf3280c48c67e731d8290ad3d730f8be9dc07946923005c8"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -207,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.16.5"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c275a07127c1aca33031a563e384ffdd485aee34ef131116fcd58e3430d1742b"
+checksum = "0f6cb136e222e49115b3c51c32792886defbfb0adead26a688142b346a0b9ffc"
 dependencies = [
  "libc",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,14 +37,14 @@ unstable-simd = [
 ]
 
 [dependencies]
-ahash = { version = "0.7", default_features = false }
+ahash = { version = "0.7.6", default_features = false }
 associative-cache = { version = "1" }
 bytecount = { version = "^0.6.2", default_features = false, features = ["runtime-dispatch-simd"] }
 encoding_rs = { version = "0.8", default_features = false }
 inlinable_string = { version = "0.1" }
 itoa = { version = "1", default_features = false }
 once_cell = { version = "1", default_features = false }
-pyo3 = { version = "^0.16.0", default_features = false, features = ["extension-module"]}
+pyo3 = { version = "0.17.3", default_features = false, features = ["extension-module"]}
 ryu = { version = "1", default_features = false }
 serde = { version = "1", default_features = false }
 simdutf8 = { version = "0.1", default_features = false, features = ["std"] }
@@ -54,7 +54,7 @@ rmp-serde = {version = "1"}
 
 
 [build-dependencies]
-pyo3-build-config = { version = "^0.16.0" }
+pyo3-build-config = { version = "0.17.3" }
 
 [profile.release]
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -811,7 +811,7 @@ This is an example of building a wheel using the repository as source,
 pip install maturin
 curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2021-05-25 --profile minimal -y
 export RUSTFLAGS="-C target-cpu=k8"
-maturin build --no-sdist --release --strip --manylinux off
+maturin build --release --strip --manylinux off
 ls -1 target/wheels
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ormsgpack"
 repository = "https://github.com/aviramha/ormsgpack"
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -11,12 +11,11 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python",
     "Programming Language :: Rust",
@@ -33,5 +32,5 @@ strip = true
 
 [tool.black]
 line-length = 88
-target-version = ['py36', 'py37', 'py38', 'py39', 'py310']
+target-version = ['py37', 'py38', 'py39', 'py310', 'py311']
 include = '\.pyi?$'

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -2,6 +2,6 @@
 
 rm -f target/wheels/*
 
-maturin build --no-sdist --manylinux off -i python3 --release "$@"
+maturin build --manylinux off -i python3 --release "$@"
 
 pip install --force $(find target/wheels -name "*cp3*")

--- a/src/serialize/datetime.rs
+++ b/src/serialize/datetime.rs
@@ -40,7 +40,7 @@ impl Date {
     }
     pub fn write_buf(&self, buf: &mut DateTimeBuffer) {
         {
-            let year = ffi!(PyDateTime_GET_YEAR(self.ptr)) as i32;
+            let year: i32 = ffi!(PyDateTime_GET_YEAR(self.ptr)) as _;
             let mut yearbuf = itoa::Buffer::new();
             let formatted = yearbuf.format(year);
             if unlikely!(year < 1000) {
@@ -84,7 +84,7 @@ pub struct Time {
 
 impl Time {
     pub fn new(ptr: *mut pyo3::ffi::PyObject, opts: Opt) -> Result<Self, TimeError> {
-        if unsafe { (*(ptr as *mut pyo3::ffi::PyDateTime_Time)).hastzinfo == 1 } {
+        if unsafe { (*(ptr as *mut pyo3::ffi::PyDateTime_Time)).hastzinfo != 0 } {
             return Err(TimeError::HasTimezone);
         }
         Ok(Time {
@@ -143,7 +143,7 @@ impl DateTime {
         }
     }
     pub fn write_buf(&self, buf: &mut DateTimeBuffer) -> Result<(), DateTimeError> {
-        let has_tz = unsafe { (*(self.ptr as *mut pyo3::ffi::PyDateTime_DateTime)).hastzinfo == 1 };
+        let has_tz = unsafe { (*(self.ptr as *mut pyo3::ffi::PyDateTime_DateTime)).hastzinfo != 0 };
         let offset_day: i32;
         let mut offset_second: i32;
         if !has_tz {
@@ -154,7 +154,7 @@ impl DateTime {
             if ffi!(PyObject_HasAttr(tzinfo, CONVERT_METHOD_STR)) == 1 {
                 // pendulum
                 let offset = call_method!(self.ptr, UTCOFFSET_METHOD_STR);
-                offset_second = ffi!(PyDateTime_DELTA_GET_SECONDS(offset)) as i32;
+                offset_second = ffi!(PyDateTime_DELTA_GET_SECONDS(offset)) as _;
                 offset_day = ffi!(PyDateTime_DELTA_GET_DAYS(offset));
                 ffi!(Py_DECREF(offset));
             } else if ffi!(PyObject_HasAttr(tzinfo, NORMALIZE_METHOD_STR)) == 1 {
@@ -162,13 +162,13 @@ impl DateTime {
                 let method_ptr = call_method!(tzinfo, NORMALIZE_METHOD_STR, self.ptr);
                 let offset = call_method!(method_ptr, UTCOFFSET_METHOD_STR);
                 ffi!(Py_DECREF(method_ptr));
-                offset_second = ffi!(PyDateTime_DELTA_GET_SECONDS(offset)) as i32;
+                offset_second = ffi!(PyDateTime_DELTA_GET_SECONDS(offset)) as _;
                 offset_day = ffi!(PyDateTime_DELTA_GET_DAYS(offset));
                 ffi!(Py_DECREF(offset));
             } else if ffi!(PyObject_HasAttr(tzinfo, DST_STR)) == 1 {
                 // dateutil/arrow, datetime.timezone.utc
                 let offset = call_method!(tzinfo, UTCOFFSET_METHOD_STR, self.ptr);
-                offset_second = ffi!(PyDateTime_DELTA_GET_SECONDS(offset)) as i32;
+                offset_second = ffi!(PyDateTime_DELTA_GET_SECONDS(offset)) as _;
                 offset_day = ffi!(PyDateTime_DELTA_GET_DAYS(offset));
                 ffi!(Py_DECREF(offset));
             } else {
@@ -176,7 +176,7 @@ impl DateTime {
             }
         };
         {
-            let year = ffi!(PyDateTime_GET_YEAR(self.ptr)) as i32;
+            let year: i32 = ffi!(PyDateTime_GET_YEAR(self.ptr)) as _;
             let mut yearbuf = itoa::Buffer::new();
             let formatted = yearbuf.format(year);
             if unlikely!(year < 1000) {

--- a/src/serialize/dict.rs
+++ b/src/serialize/dict.rs
@@ -152,11 +152,10 @@ impl DictNonStrKey {
         }
     }
 
-    fn pyobject_to_string(
-        &self,
+    fn pyobject_to_string<'a>(
         key: *mut pyo3::ffi::PyObject,
         opts: crate::opt::Opt,
-    ) -> Result<Key, NonStrError> {
+    ) -> Result<Key<'a>, NonStrError> {
         match pyobject_to_obtype(key, opts) {
             ObType::None => Ok(Key::String(InlinableString::from("null"))),
             ObType::Bool => {
@@ -212,7 +211,7 @@ impl DictNonStrKey {
             ObType::Enum => {
                 let value = ffi!(PyObject_GetAttr(key, VALUE_STR));
                 ffi!(Py_DECREF(value));
-                self.pyobject_to_string(value, opts)
+                DictNonStrKey::pyobject_to_string(value, opts)
             }
             ObType::Str => {
                 // because of ObType::Enum
@@ -290,7 +289,7 @@ impl Serialize for DictNonStrKey {
                     value,
                 ));
             } else {
-                match self.pyobject_to_string(key, opts) {
+                match DictNonStrKey::pyobject_to_string(key, opts) {
                     Ok(key_as_str) => items.push((key_as_str, value)),
                     Err(NonStrError::TimeTzinfo) => err!(TIME_HAS_TZINFO),
                     Err(NonStrError::IntegerRange) => {

--- a/src/serialize/writer.rs
+++ b/src/serialize/writer.rs
@@ -45,7 +45,7 @@ impl BytesWriter {
         unsafe {
             _PyBytes_Resize(
                 &mut self.bytes as *mut *mut PyBytesObject as *mut *mut PyObject,
-                len as isize,
+                len as _,
             );
         }
     }

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -429,11 +429,11 @@ def test_datetime_partial_second_pytz():
                     0,
                     27,
                     87,
-                    tzinfo=pytz.timezone("Europe/Amsterdam"),
+                    tzinfo=pytz.timezone("Asia/Vladivostok"),
                 )
             ]
         )
-        == msgpack.packb(["1937-01-01T12:00:27.000087+00:20"])
+        == msgpack.packb(["1937-01-01T12:00:27.000087+10:00"])
     )
 
 
@@ -446,10 +446,10 @@ def test_datetime_partial_second_dateutil():
     assert ormsgpack.packb(
         [
             datetime.datetime(
-                1937, 1, 1, 12, 0, 27, 87, tzinfo=tz.gettz("Europe/Amsterdam")
+                1937, 1, 1, 12, 0, 27, 87, tzinfo=tz.gettz("Asia/Vladivostok")
             )
         ]
-    ) == msgpack.packb(["1937-01-01T12:00:27.000087+00:20"])
+    ) == msgpack.packb(["1937-01-01T12:00:27.000087+10:00"])
 
 
 def test_datetime_microsecond_max():
@@ -558,12 +558,12 @@ def test_datetime_utc_z_with_tz():
         ormsgpack.packb(
             [
                 datetime.datetime(
-                    1937, 1, 1, 12, 0, 27, 87, tzinfo=tz.gettz("Europe/Amsterdam")
+                    1937, 1, 1, 12, 0, 27, 87, tzinfo=tz.gettz("Asia/Vladivostok")
                 )
             ],
             option=ormsgpack.OPT_UTC_Z,
         )
-        == msgpack.packb(["1937-01-01T12:00:27.000087+00:20"])
+        == msgpack.packb(["1937-01-01T12:00:27.000087+10:00"])
     )
 
 


### PR DESCRIPTION
##### Changelog:
- Add `.idea` to ignored files.
- Removed duplicate of `Programming Language :: Python :: 3.10`.
- Add information about Python 3.11 support.
- Add Python 3.11 to release.yml in github actions.
- Add support for maturin 0.13.
- Fix Clippy warnings and errors.
- Update ahash, pyo3 and pyo3-build-config.
- Change timezone which has different hours.
- Fix Github actions pip update.

#128