### PR TITLE
fix: once_cell poisoning on parallel initialization

### DIFF
--- a/src/lazy.rs
+++ b/src/lazy.rs
@@ -1,0 +1,66 @@
+use std::cell::UnsafeCell;
+use std::ops::Deref;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use pyo3::Python;
+
+pub struct ThreadSafeLazy<T, F = fn() -> T> {
+    /// A flag which indicates whether the value has been initialized.
+    initialized: AtomicBool,
+    /// The inner value. This is wrapped in an `UnsafeCell` to allow for interior mutability.
+    cell: UnsafeCell<Option<T>>,
+    /// The initializer function. The return value of the function will be stored in the cell.
+    initializer: F,
+}
+
+impl<T, F> ThreadSafeLazy<T, F> {
+    pub const fn new(initializer: F) -> ThreadSafeLazy<T, F> {
+        Self {
+            initialized: AtomicBool::new(false),
+            cell: UnsafeCell::new(None),
+            initializer,
+        }
+    }
+}
+
+impl<T, F: Fn() -> T> ThreadSafeLazy<T, F> {
+    /// Initializes the value of this lazy cell.
+    ///
+    /// This function is safe to call concurrently from multiple threads. The function uses the
+    /// Python Global Interpreter Lock to ensure that the cell is not written to concurrently.
+    fn initialize(&self) {
+        Python::with_gil(|_py| {
+            // It is possible that the initializer function drops the GIL
+            // So by the time we re-require the GIL here, cell might have already been initialized
+            // by another thread
+            let res = (self.initializer)();
+
+            // If that is the case, then we just drop the value we just computed
+            let cell = unsafe { &mut *self.cell.get() };
+            if cell.is_some() {
+                return;
+            }
+
+            *cell = Some(res);
+            self.initialized.store(true, Ordering::SeqCst);
+        });
+    }
+
+    /// Forces the evaluation of this lazy cell and returns a reference to the result.
+    pub fn force(self: &ThreadSafeLazy<T, F>) -> &T {
+        // If the value has not been initialized yet, we need to do so.
+        if !self.initialized.load(Ordering::Relaxed) {
+            self.initialize();
+        }
+
+        // The value has been initialized, so it is safe to read.
+        unsafe { &*self.cell.get() }.as_ref().unwrap()
+    }
+}
+
+impl<T, F: Fn() -> T> Deref for ThreadSafeLazy<T, F> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        ThreadSafeLazy::force(self)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ mod util;
 mod deserialize;
 mod exc;
 mod ffi;
+mod lazy;
 mod opt;
 mod serialize;
 mod typeref;

--- a/src/serialize/numpy.rs
+++ b/src/serialize/numpy.rs
@@ -1,7 +1,6 @@
 use crate::typeref::{ARRAY_STRUCT_STR, NUMPY_TYPES};
 use pyo3::ffi::*;
 use serde::ser::{Serialize, SerializeSeq, Serializer};
-use std::ops::DerefMut;
 use std::os::raw::{c_char, c_int, c_void};
 
 macro_rules! slice {
@@ -435,7 +434,7 @@ impl Serialize for NumpyScalar {
     {
         unsafe {
             let ob_type = ob_type!(self.ptr);
-            let scalar_types = NUMPY_TYPES.deref_mut().as_ref().unwrap();
+            let scalar_types = NUMPY_TYPES.as_ref().unwrap();
             if ob_type == scalar_types.float64 {
                 (*(self.ptr as *mut NumpyFloat64)).serialize(serializer)
             } else if ob_type == scalar_types.float32 {

--- a/src/typeref.rs
+++ b/src/typeref.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use ahash::RandomState;
-use once_cell::unsync::Lazy;
 use pyo3::ffi::*;
 use std::os::raw::c_char;
 use std::ptr::NonNull;
 use std::sync::Once;
+
+use crate::lazy::ThreadSafeLazy;
 
 pub struct NumpyTypes {
     pub array: *mut PyTypeObject,
@@ -37,8 +38,10 @@ pub static mut TIME_TYPE: *mut PyTypeObject = 0 as *mut PyTypeObject;
 pub static mut TUPLE_TYPE: *mut PyTypeObject = 0 as *mut PyTypeObject;
 pub static mut UUID_TYPE: *mut PyTypeObject = 0 as *mut PyTypeObject;
 pub static mut ENUM_TYPE: *mut PyTypeObject = 0 as *mut PyTypeObject;
-pub static mut NUMPY_TYPES: Lazy<Option<NumpyTypes>> = Lazy::new(|| unsafe { load_numpy_types() });
-pub static mut FIELD_TYPE: Lazy<NonNull<PyObject>> = Lazy::new(|| unsafe { look_up_field_type() });
+pub static mut NUMPY_TYPES: ThreadSafeLazy<Option<NumpyTypes>> =
+    ThreadSafeLazy::new(|| unsafe { load_numpy_types() });
+pub static mut FIELD_TYPE: ThreadSafeLazy<NonNull<PyObject>> =
+    ThreadSafeLazy::new(|| unsafe { look_up_field_type() });
 
 pub static mut BYTES_TYPE: *mut PyTypeObject = 0 as *mut PyTypeObject;
 pub static mut BYTEARRAY_TYPE: *mut PyTypeObject = 0 as *mut PyTypeObject;
@@ -60,7 +63,8 @@ pub static mut VALUE_STR: *mut PyObject = 0 as *mut PyObject;
 pub static mut STR_HASH_FUNCTION: Option<hashfunc> = None;
 pub static mut DEFAULT: *mut PyObject = 0 as *mut PyObject;
 pub static mut OPTION: *mut PyObject = 0 as *mut PyObject;
-pub static mut HASH_BUILDER: Lazy<ahash::RandomState> = Lazy::new(|| unsafe {
+
+pub static mut HASH_BUILDER: ThreadSafeLazy<ahash::RandomState> = ThreadSafeLazy::new(|| unsafe {
     RandomState::with_seeds(
         VALUE_STR as u64,
         DICT_TYPE as u64,


### PR DESCRIPTION
Closes #152 

As explained in https://github.com/aviramha/ormsgpack/issues/152#issue-1642316866, the error `thread '<unnamed>' panicked at 'Lazy instance has previously been poisoned'` can occur in an asynchronous environment.

In particular, this happens when the library is initialized in parallel. The global constant `NUMPY_TYPES` is lazily initialized using the `unsync` (non thread safe) version of `Lazy`. 
https://github.com/aviramha/ormsgpack/blob/8f389c96f317cbeea5bb9311d2b57dbaf0581601/src/typeref.rs#L4
https://github.com/aviramha/ormsgpack/blob/8f389c96f317cbeea5bb9311d2b57dbaf0581601/src/typeref.rs#L40

Coincidentally, this issue was addressed upstream just last week: https://github.com/ijl/orjson/issues/369. Their fix ijl/orjson@dc13054fa80432554fd9cd2f2e331eda642252a9 switched out `once_cell::unsync::Lazy` for `once_cell::race::OnceBox`. 

However, in my testing I found that this doesn't completely fix the issue, as now deadlocks can occur. This is also explained in the documentation of PyO3: https://pyo3.rs/v0.18.2/faq#im-experiencing-deadlocks-using-pyo3-with-lazy_static-or-once_cell.

Per the documentation of PyO3, I swapped out `once_cell::unsync::Lazy` with `pyo3::once_cell::GILOnceCell`. For the rest, the changes are identical to those of commit ijl/orjson@dc13054fa80432554fd9cd2f2e331eda642252a9. This has fixed the issue as we found it in our code base.