### PR TITLE
Streamline serialization of dicts with non-str keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,12 +60,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inlinable_string"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
-
-[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,7 +120,6 @@ dependencies = [
  "associative-cache",
  "bytecount",
  "encoding_rs",
- "inlinable_string",
  "itoa",
  "once_cell",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ ahash = { version = "0.8", default_features = false }
 associative-cache = { version = "2" }
 bytecount = { version = "^0.6.2", default_features = false, features = ["runtime-dispatch-simd"] }
 encoding_rs = { version = "0.8", default_features = false }
-inlinable_string = { version = "0.1" }
 itoa = { version = "1", default_features = false }
 once_cell = { version = "1", default_features = false }
 pyo3 = { version = "0.19.2", default_features = false, features = ["extension-module"]}

--- a/benchmarks/bench_non_str_keys.py
+++ b/benchmarks/bench_non_str_keys.py
@@ -1,0 +1,29 @@
+import datetime
+import random
+from time import mktime
+
+import msgpack
+import pytest
+
+import ormsgpack
+
+data = []
+for year in range(1920, 2020):
+    start = datetime.date(year, 1, 1)
+    array = [
+        (int(mktime((start + datetime.timedelta(days=i)).timetuple())), i + 1)
+        for i in range(0, 365)
+    ]
+    array.append(("other", 0))
+    random.shuffle(array)
+    data.append(dict(array))
+
+
+def test_msgpack_packb(benchmark):
+    benchmark.group = "non_str_keys"
+    benchmark(msgpack.packb, data)
+
+
+def test_ormsgpack_packb(benchmark):
+    benchmark.group = "non_str_keys"
+    benchmark(ormsgpack.packb, data, option=ormsgpack.OPT_NON_STR_KEYS)

--- a/src/serialize/dict.rs
+++ b/src/serialize/dict.rs
@@ -2,17 +2,12 @@
 
 use crate::exc::*;
 use crate::ffi::PyDict_GET_SIZE;
-use crate::ffi::*;
 use crate::opt::*;
-use crate::serialize::datetime::*;
 use crate::serialize::serializer::pyobject_to_obtype;
 use crate::serialize::serializer::*;
-use crate::serialize::uuid::*;
 use crate::typeref::*;
 use crate::unicode::*;
-use inlinable_string::InlinableString;
 use serde::ser::{Serialize, SerializeMap, Serializer};
-use smallvec::SmallVec;
 use std::ptr::NonNull;
 
 pub struct Dict {
@@ -21,38 +16,6 @@ pub struct Dict {
     default_calls: u8,
     recursion: u8,
     default: Option<NonNull<pyo3::ffi::PyObject>>,
-}
-
-#[derive(Clone)]
-enum Key<'p> {
-    String(InlinableString),
-    Bytes(&'p [u8]),
-    Bool(bool),
-    UInt(u64),
-    SInt(i64),
-    Float(f64),
-    Tuple(*mut pyo3::ffi::PyObject),
-}
-
-// serialize_entry() when T is &[u8] serializes it into a byte array/tuple, where desired behavior is bytes.
-#[repr(transparent)]
-pub struct BytesKeySerializer<'p> {
-    buf: &'p [u8],
-}
-
-impl<'p> BytesKeySerializer<'p> {
-    pub fn new(buf: &'p [u8]) -> Self {
-        BytesKeySerializer { buf: buf }
-    }
-}
-
-impl<'p> Serialize for BytesKeySerializer<'p> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_bytes(self.buf)
-    }
 }
 
 impl Dict {
@@ -118,14 +81,6 @@ impl Serialize for Dict {
     }
 }
 
-enum NonStrError {
-    DatetimeLibraryUnsupported,
-    IntegerRange,
-    InvalidStr,
-    TimeTzinfo,
-    UnsupportedType,
-}
-
 pub struct DictNonStrKey {
     ptr: *mut pyo3::ffi::PyObject,
     opts: Opt,
@@ -150,102 +105,6 @@ impl DictNonStrKey {
             default: default,
         }
     }
-
-    fn pyobject_to_string<'a>(
-        key: *mut pyo3::ffi::PyObject,
-        opts: crate::opt::Opt,
-    ) -> Result<Key<'a>, NonStrError> {
-        match pyobject_to_obtype(key, opts) {
-            ObType::None => Ok(Key::String(InlinableString::from("null"))),
-            ObType::Bool => {
-                let key = unsafe { key == TRUE };
-                Ok(Key::Bool(key))
-            }
-            ObType::Int => {
-                let ival = ffi!(PyLong_AsLongLong(key));
-                if unlikely!(ival == -1 && !ffi!(PyErr_Occurred()).is_null()) {
-                    ffi!(PyErr_Clear());
-                    let uval = ffi!(PyLong_AsUnsignedLongLong(key));
-                    if unlikely!(uval == u64::MAX && !ffi!(PyErr_Occurred()).is_null()) {
-                        return Err(NonStrError::IntegerRange);
-                    }
-                    Ok(Key::UInt(uval))
-                } else {
-                    Ok(Key::SInt(ival))
-                }
-            }
-            ObType::Float => {
-                let val = ffi!(PyFloat_AS_DOUBLE(key));
-                Ok(Key::Float(val))
-            }
-            ObType::Datetime => {
-                let mut buf: DateTimeBuffer = smallvec::SmallVec::with_capacity(32);
-                let dt = DateTime::new(key, opts);
-                dt.write_buf(&mut buf)
-                    .map_err(|_| NonStrError::DatetimeLibraryUnsupported)?;
-                let key_as_str = str_from_slice!(buf.as_ptr(), buf.len());
-                Ok(Key::String(InlinableString::from(key_as_str)))
-            }
-            ObType::Date => {
-                let mut buf: DateTimeBuffer = smallvec::SmallVec::with_capacity(32);
-                Date::new(key).write_buf(&mut buf);
-                let key_as_str = str_from_slice!(buf.as_ptr(), buf.len());
-                Ok(Key::String(InlinableString::from(key_as_str)))
-            }
-            ObType::Time => match Time::new(key, opts) {
-                Ok(val) => {
-                    let mut buf: DateTimeBuffer = smallvec::SmallVec::with_capacity(32);
-                    val.write_buf(&mut buf);
-                    let key_as_str = str_from_slice!(buf.as_ptr(), buf.len());
-                    Ok(Key::String(InlinableString::from(key_as_str)))
-                }
-                Err(TimeError::HasTimezone) => Err(NonStrError::TimeTzinfo),
-            },
-            ObType::Uuid => {
-                let mut buf: UUIDBuffer = smallvec::SmallVec::with_capacity(64);
-                UUID::new(key).write_buf(&mut buf);
-                let key_as_str = str_from_slice!(buf.as_ptr(), buf.len());
-                Ok(Key::String(InlinableString::from(key_as_str)))
-            }
-            ObType::Enum => {
-                let value = ffi!(PyObject_GetAttr(key, VALUE_STR));
-                ffi!(Py_DECREF(value));
-                DictNonStrKey::pyobject_to_string(value, opts)
-            }
-            ObType::Str => {
-                // because of ObType::Enum
-                let uni = unicode_to_str(key);
-                if unlikely!(uni.is_none()) {
-                    Err(NonStrError::InvalidStr)
-                } else {
-                    Ok(Key::String(InlinableString::from(uni.unwrap())))
-                }
-            }
-            ObType::Bytes => {
-                let buffer = unsafe { PyBytes_AS_STRING(key) as *const u8 };
-                let length = unsafe { PyBytes_GET_SIZE(key) as usize };
-                Ok(Key::Bytes(unsafe {
-                    std::slice::from_raw_parts(buffer, length)
-                }))
-            }
-            ObType::StrSubclass => {
-                let uni = unicode_to_str_via_ffi(key);
-                if unlikely!(uni.is_none()) {
-                    Err(NonStrError::InvalidStr)
-                } else {
-                    Ok(Key::String(InlinableString::from(uni.unwrap())))
-                }
-            }
-            ObType::Tuple => Ok(Key::Tuple(key)),
-            ObType::NumpyScalar
-            | ObType::NumpyArray
-            | ObType::Dict
-            | ObType::List
-            | ObType::Dataclass
-            | ObType::Pydantic
-            | ObType::Unknown => Err(NonStrError::UnsupportedType),
-        }
-    }
 }
 
 impl Serialize for DictNonStrKey {
@@ -255,12 +114,11 @@ impl Serialize for DictNonStrKey {
         S: Serializer,
     {
         let len = unsafe { PyDict_GET_SIZE(self.ptr) as usize };
-        let mut items: SmallVec<[(Key, *mut pyo3::ffi::PyObject); 8]> =
-            SmallVec::with_capacity(len);
         let mut pos = 0isize;
         let mut key: *mut pyo3::ffi::PyObject = std::ptr::null_mut();
         let mut value: *mut pyo3::ffi::PyObject = std::ptr::null_mut();
         let opts = self.opts & NOT_PASSTHROUGH;
+        let mut map = serializer.serialize_map(None).unwrap();
         for _ in 0..=len - 1 {
             unsafe {
                 pyo3::ffi::_PyDict_Next(
@@ -276,104 +134,45 @@ impl Serialize for DictNonStrKey {
                 if unlikely!(data.is_none()) {
                     err!(INVALID_STR)
                 }
-                items.push((Key::String(InlinableString::from(data.unwrap())), value));
+                map.serialize_entry(
+                    data.unwrap(),
+                    &PyObjectSerializer::new(
+                        value,
+                        self.opts,
+                        self.default_calls,
+                        self.recursion + 1,
+                        self.default,
+                    ),
+                )?;
             } else {
-                match DictNonStrKey::pyobject_to_string(key, opts) {
-                    Ok(key_as_str) => items.push((key_as_str, value)),
-                    Err(NonStrError::TimeTzinfo) => err!(TIME_HAS_TZINFO),
-                    Err(NonStrError::IntegerRange) => {
-                        err!("Dict integer key must be within 64-bit range")
-                    }
-                    Err(NonStrError::DatetimeLibraryUnsupported) => {
-                        err!(DATETIME_LIBRARY_UNSUPPORTED)
-                    }
-                    Err(NonStrError::InvalidStr) => err!(INVALID_STR),
-                    Err(NonStrError::UnsupportedType) => {
+                match pyobject_to_obtype(key, opts) {
+                    ObType::NumpyScalar
+                    | ObType::NumpyArray
+                    | ObType::Dict
+                    | ObType::List
+                    | ObType::Dataclass
+                    | ObType::Pydantic
+                    | ObType::Unknown => {
                         err!("Dict key must a type serializable with OPT_NON_STR_KEYS")
                     }
+                    _ => (),
                 }
-            }
-        }
-
-        let mut map = serializer.serialize_map(None).unwrap();
-        for (key, val) in items.iter() {
-            match key {
-                Key::String(k) => map.serialize_entry(
-                    str_from_slice!(k.as_ptr(), k.len()),
+                map.serialize_entry(
                     &PyObjectSerializer::new(
-                        *val,
-                        self.opts,
-                        self.default_calls,
-                        self.recursion + 1,
-                        self.default,
-                    ),
-                )?,
-                Key::Bytes(k) => map.serialize_entry(
-                    &BytesKeySerializer::new(k),
-                    &PyObjectSerializer::new(
-                        *val,
-                        self.opts,
-                        self.default_calls,
-                        self.recursion + 1,
-                        self.default,
-                    ),
-                )?,
-                Key::SInt(k) => map.serialize_entry(
-                    k,
-                    &PyObjectSerializer::new(
-                        *val,
-                        self.opts,
-                        self.default_calls,
-                        self.recursion + 1,
-                        self.default,
-                    ),
-                )?,
-                Key::UInt(k) => map.serialize_entry(
-                    k,
-                    &PyObjectSerializer::new(
-                        *val,
-                        self.opts,
-                        self.default_calls,
-                        self.recursion + 1,
-                        self.default,
-                    ),
-                )?,
-                Key::Float(k) => map.serialize_entry(
-                    k,
-                    &PyObjectSerializer::new(
-                        *val,
-                        self.opts,
-                        self.default_calls,
-                        self.recursion + 1,
-                        self.default,
-                    ),
-                )?,
-                Key::Bool(k) => map.serialize_entry(
-                    k,
-                    &PyObjectSerializer::new(
-                        *val,
-                        self.opts,
-                        self.default_calls,
-                        self.recursion + 1,
-                        self.default,
-                    ),
-                )?,
-                Key::Tuple(k) => map.serialize_entry(
-                    &PyObjectSerializer::new(
-                        *k,
-                        self.opts,
+                        key,
+                        opts,
                         self.default_calls,
                         self.recursion + 1,
                         self.default,
                     ),
                     &PyObjectSerializer::new(
-                        *val,
+                        value,
                         self.opts,
                         self.default_calls,
                         self.recursion + 1,
                         self.default,
                     ),
-                )?,
+                )?;
             }
         }
         map.end()


### PR DESCRIPTION
The serializer for dicts with non-str keys duplicates the code to serialize scalar types instead of using a PyObjectSerializer for keys, seemingly for speed reasons. However, based on the orjson benchmark for non-str keys, the code using a PyObjectSerializer is faster:

Name (time in ms)           Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
ormsgpack(master)        1.3515 (1.0)      3.9225 (1.0)      1.3902 (1.0)      0.0977 (1.0)      1.3750 (1.0)      0.0173 (1.0)        73;362  719.3031 (1.0)        3456
ormsgpack(head)          1.1721 (1.0)      2.8177 (1.0)      1.2137 (1.0)      0.1055 (1.0)      1.1941 (1.0)      0.0175 (1.0)       104;436  823.9116 (1.0)        4089