### PR TITLE
Improve datetime tests

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,10 +1,11 @@
 arrow
 numpy
-pendulum;python_version<"3.12"
+pendulum
 psutil;sys_platform!="windows"
 pytest
 pytz
 xxhash==1.4.3;sys_platform!="windows" and python_version<"3.9" # creates non-compact ASCII for test_str_ascii
 msgpack
 pydantic
+tzdata
 types-pytz


### PR DESCRIPTION
- remove code duplication in timezone tests
- add missing coverage for some timezone libraries
- fix UTC+00:20 timezone test with pendulum 3
- enable timezone tests with pendulum 3 on python 3.12
- enable timezone tests with zoneinfo on windows