### PR TITLE
Fix crash with python 3.11 (#223)

### DIFF
--- a/src/typeref.rs
+++ b/src/typeref.rs
@@ -149,7 +149,9 @@ pub fn init_typerefs() {
         DEFAULT = PyUnicode_InternFromString("default\0".as_ptr() as *const c_char);
         EXT_HOOK = PyUnicode_InternFromString("ext_hook\0".as_ptr() as *const c_char);
         OPTION = PyUnicode_InternFromString("option\0".as_ptr() as *const c_char);
+        Py_INCREF(PyExc_TypeError);
         MsgpackEncodeError = PyExc_TypeError;
+        Py_INCREF(PyExc_ValueError);
         MsgpackDecodeError = PyExc_ValueError;
 
         HASH_BUILDER.get_or_init(ahash_init);


### PR DESCRIPTION
We borrow a reference to the static exceptions TypeError and ValueError and pass these objects to PyModule_AddObject, which steals a reference. In Python 3.11 and newer, Py_Finalize() deallocates static exceptions

https://github.com/python/cpython/pull/30805

This results in a crash on termination, because _PyStaticType_Dealloc indirectly calls _Py_Dealloc on the objects as the reference count drops to zero. The issue does not occur in Python 3.12 and newer because the objects are immortal.