### PR TITLE
Optimize deserialization of strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,15 +15,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "any_all_workaround"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88fea40735f2cc320a5133ce772d39c571bd6c9b0d4c1a326926eecdd5af2e86"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,16 +52,6 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
-dependencies = [
- "any_all_workaround",
- "cfg-if",
-]
 
 [[package]]
 name = "half"
@@ -126,7 +107,6 @@ dependencies = [
  "bytecount",
  "byteorder",
  "chrono",
- "encoding_rs",
  "half",
  "itoa",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ default = ["unstable-simd"]
 # Use SIMD intrinsics. This requires Rust on the nightly channel.
 unstable-simd = [
     "bytecount/generic-simd",
-    "encoding_rs/simd-accel",
 ]
 
 [dependencies]
@@ -42,7 +41,6 @@ ahash = { version = "0.8", default-features = false }
 bytecount = { version = "^0.6.7", default-features = false, features = ["runtime-dispatch-simd"] }
 byteorder = { version = "1.5.0", default-features = false, features = ["std"] }
 chrono = { version = "0.4.38", default-features = false }
-encoding_rs = { version = "0.8", default-features = false }
 half = { version = "2.4.1", default-features = false }
 itoa = { version = "1", default-features = false }
 once_cell = { version = "1", default-features = false, features = ["race"] }


### PR DESCRIPTION
PyUnicode_New needs to know the maximum code point to be placed in the new unicode object. An upper bound of the maximum code point in a utf-8 string is

- 1114111 if m >= 0xf0
- 65535 if 0xc4 <= m < 0xf0
- 255 if m < 0xc4

where m is the maximum byte in the string.

This commit changes the string deserializer to find the upper bound based on the above formulation, using str::bytes().max(). The rust compiler vectorizes str::bytes().max() (PMAXUB on x86_64, UMAX and UMAXV on arm64), so there is no need to manually vectorize the operation using std::arch or std::simd.