### PR TITLE
Reject dictionary keys with nested dataclasses or pydantic models

### DIFF
--- a/src/serialize/dict.rs
+++ b/src/serialize/dict.rs
@@ -3,7 +3,6 @@
 use crate::exc::*;
 use crate::ffi::PyDictIter;
 use crate::opt::*;
-use crate::serialize::serializer::pyobject_to_obtype;
 use crate::serialize::serializer::*;
 use crate::typeref::*;
 use crate::unicode::*;
@@ -251,33 +250,8 @@ impl Serialize for DictWithNonStrKeys {
                     ),
                 )?;
             } else {
-                match pyobject_to_obtype(key.as_ptr(), opts) {
-                    ObType::Bool
-                    | ObType::Bytes
-                    | ObType::Date
-                    | ObType::Datetime
-                    | ObType::Enum
-                    | ObType::Ext
-                    | ObType::Float
-                    | ObType::Int
-                    | ObType::None
-                    | ObType::Str
-                    | ObType::StrSubclass
-                    | ObType::Time
-                    | ObType::Tuple
-                    | ObType::Uuid => (),
-                    _ => {
-                        err!("Dict key must a type serializable with OPT_NON_STR_KEYS")
-                    }
-                }
                 map.serialize_entry(
-                    &PyObject::new(
-                        key.as_ptr(),
-                        opts,
-                        self.default_calls,
-                        self.recursion + 1,
-                        self.default,
-                    ),
+                    &DictKey::new(key.as_ptr(), opts, self.recursion + 1),
                     &PyObject::new(
                         value.as_ptr(),
                         self.opts,

--- a/src/serialize/serializer.rs
+++ b/src/serialize/serializer.rs
@@ -525,201 +525,24 @@ pub fn serialize(
     }
 }
 
-#[derive(Copy, Clone)]
-pub enum ObType {
-    Str,
-    Bytes,
-    Int,
-    Bool,
-    None,
-    Float,
-    List,
-    Dict,
-    Datetime,
-    Date,
-    Time,
-    Tuple,
-    Uuid,
-    Dataclass,
-    NumpyBool,
-    NumpyDatetime64,
-    NumpyFloat16,
-    NumpyFloat32,
-    NumpyFloat64,
-    NumpyInt8,
-    NumpyInt16,
-    NumpyInt32,
-    NumpyInt64,
-    NumpyUint8,
-    NumpyUint16,
-    NumpyUint32,
-    NumpyUint64,
-    NumpyArray,
-    Pydantic,
-    Enum,
-    StrSubclass,
-    Ext,
-    Unknown,
-}
-
-pub fn pyobject_to_obtype(obj: *mut pyo3::ffi::PyObject, opts: Opt) -> ObType {
-    let ob_type = ob_type!(obj);
-    if py_is!(ob_type, STR_TYPE) {
-        ObType::Str
-    } else if py_is!(ob_type, BYTES_TYPE) {
-        ObType::Bytes
-    } else if py_is!(ob_type, INT_TYPE)
-        && (opts & PASSTHROUGH_BIG_INT == 0
-            || ffi!(_PyLong_NumBits(obj)) <= {
-                if pylong_is_positive(obj) {
-                    64
-                } else {
-                    63
-                }
-            })
-    {
-        ObType::Int
-    } else if py_is!(ob_type, BOOL_TYPE) {
-        ObType::Bool
-    } else if py_is!(obj, NONE) {
-        ObType::None
-    } else if py_is!(ob_type, FLOAT_TYPE) {
-        ObType::Float
-    } else if py_is!(ob_type, LIST_TYPE) {
-        ObType::List
-    } else if py_is!(ob_type, DICT_TYPE) {
-        ObType::Dict
-    } else if py_is!(ob_type, DATETIME_TYPE) && opts & PASSTHROUGH_DATETIME == 0 {
-        ObType::Datetime
-    } else {
-        pyobject_to_obtype_unlikely(obj, opts)
-    }
-}
-
 macro_rules! is_subclass {
     ($ob_type:expr, $flag:ident) => {
         unsafe { (((*$ob_type).tp_flags & pyo3::ffi::$flag) != 0) }
     };
 }
 
-#[inline(never)]
-fn pyobject_to_obtype_unlikely(obj: *mut pyo3::ffi::PyObject, opts: Opt) -> ObType {
-    let ob_type = ob_type!(obj);
-
-    if opts & PASSTHROUGH_DATETIME == 0 {
-        if py_is!(ob_type, DATE_TYPE) {
-            return ObType::Date;
-        }
-        if py_is!(ob_type, TIME_TYPE) {
-            return ObType::Time;
+fn is_big_int(ptr: *mut pyo3::ffi::PyObject) -> bool {
+    ffi!(_PyLong_NumBits(ptr)) > {
+        if pylong_is_positive(ptr) {
+            64
+        } else {
+            63
         }
     }
-
-    if opts & PASSTHROUGH_TUPLE == 0 && py_is!(ob_type, TUPLE_TYPE) {
-        return ObType::Tuple;
-    }
-
-    if py_is!(ob_type, UUID_TYPE) {
-        return ObType::Uuid;
-    }
-
-    if py_is!(ob_type!(ob_type), ENUM_TYPE) {
-        return ObType::Enum;
-    }
-
-    if opts & PASSTHROUGH_SUBCLASS == 0 {
-        if is_subclass!(ob_type, Py_TPFLAGS_UNICODE_SUBCLASS) {
-            return ObType::StrSubclass;
-        }
-        if is_subclass!(ob_type, Py_TPFLAGS_LONG_SUBCLASS)
-            && (opts & PASSTHROUGH_BIG_INT == 0
-                || ffi!(_PyLong_NumBits(obj)) <= {
-                    if pylong_is_positive(obj) {
-                        64
-                    } else {
-                        63
-                    }
-                })
-        {
-            return ObType::Int;
-        }
-        if is_subclass!(ob_type, Py_TPFLAGS_LIST_SUBCLASS) {
-            return ObType::List;
-        }
-        if is_subclass!(ob_type, Py_TPFLAGS_DICT_SUBCLASS) {
-            return ObType::Dict;
-        }
-    }
-
-    if py_is!(ob_type, EXT_TYPE) {
-        return ObType::Ext;
-    }
-
-    if opts & PASSTHROUGH_DATACLASS == 0 && pydict_contains!(ob_type, DATACLASS_FIELDS_STR) {
-        return ObType::Dataclass;
-    }
-
-    if opts & SERIALIZE_PYDANTIC != 0
-        && (pydict_contains!(ob_type, PYDANTIC_FIELDS_STR)
-            || pydict_contains!(ob_type, PYDANTIC2_VALIDATOR_STR))
-    {
-        return ObType::Pydantic;
-    }
-
-    if opts & SERIALIZE_NUMPY != 0 {
-        if let Some(numpy_types) = unsafe { NUMPY_TYPES.get_or_init(load_numpy_types) } {
-            let numpy_types_ref = unsafe { numpy_types.as_ref() };
-            if ob_type == numpy_types_ref.bool_ {
-                return ObType::NumpyBool;
-            }
-            if ob_type == numpy_types_ref.datetime64 {
-                return ObType::NumpyDatetime64;
-            }
-            if ob_type == numpy_types_ref.float16 {
-                return ObType::NumpyFloat16;
-            }
-            if ob_type == numpy_types_ref.float32 {
-                return ObType::NumpyFloat32;
-            }
-            if ob_type == numpy_types_ref.float64 {
-                return ObType::NumpyFloat64;
-            }
-            if ob_type == numpy_types_ref.int8 {
-                return ObType::NumpyInt8;
-            }
-            if ob_type == numpy_types_ref.int16 {
-                return ObType::NumpyInt16;
-            }
-            if ob_type == numpy_types_ref.int32 {
-                return ObType::NumpyInt32;
-            }
-            if ob_type == numpy_types_ref.int64 {
-                return ObType::NumpyInt64;
-            }
-            if ob_type == numpy_types_ref.uint8 {
-                return ObType::NumpyUint8;
-            }
-            if ob_type == numpy_types_ref.uint16 {
-                return ObType::NumpyUint16;
-            }
-            if ob_type == numpy_types_ref.uint32 {
-                return ObType::NumpyUint32;
-            }
-            if ob_type == numpy_types_ref.uint64 {
-                return ObType::NumpyUint64;
-            }
-            if ob_type == numpy_types_ref.array {
-                return ObType::NumpyArray;
-            }
-        }
-    }
-
-    ObType::Unknown
 }
 
 pub struct PyObject {
     ptr: *mut pyo3::ffi::PyObject,
-    obtype: ObType,
     opts: Opt,
     default_calls: u8,
     recursion: u8,
@@ -736,12 +559,209 @@ impl PyObject {
     ) -> Self {
         PyObject {
             ptr: ptr,
-            obtype: pyobject_to_obtype(ptr, opts),
             opts: opts,
             default_calls: default_calls,
             recursion: recursion,
             default: default,
         }
+    }
+
+    #[inline(never)]
+    fn serialize_unlikely<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let ob_type = ob_type!(self.ptr);
+
+        if self.opts & PASSTHROUGH_DATETIME == 0 {
+            if py_is!(ob_type, DATETIME_TYPE) {
+                match DateTime::new(self.ptr, self.opts) {
+                    Ok(val) => return val.serialize(serializer),
+                    Err(err) => err!(err),
+                }
+            }
+            if py_is!(ob_type, DATE_TYPE) {
+                return Date::new(self.ptr).serialize(serializer);
+            }
+            if py_is!(ob_type, TIME_TYPE) {
+                match Time::new(self.ptr, self.opts) {
+                    Ok(val) => return val.serialize(serializer),
+                    Err(err) => err!(err),
+                };
+            }
+        }
+
+        if self.opts & PASSTHROUGH_TUPLE == 0 && py_is!(ob_type, TUPLE_TYPE) {
+            if unlikely!(self.recursion == RECURSION_LIMIT) {
+                err!(RECURSION_LIMIT_REACHED)
+            }
+            return Tuple::new(
+                self.ptr,
+                self.opts,
+                self.default_calls,
+                self.recursion,
+                self.default,
+            )
+            .serialize(serializer);
+        }
+
+        if py_is!(ob_type, UUID_TYPE) {
+            return UUID::new(self.ptr).serialize(serializer);
+        }
+
+        if py_is!(ob_type!(ob_type), ENUM_TYPE) {
+            let value = ffi!(PyObject_GetAttr(self.ptr, VALUE_STR));
+            ffi!(Py_DECREF(value));
+            return PyObject::new(
+                value,
+                self.opts,
+                self.default_calls,
+                self.recursion,
+                self.default,
+            )
+            .serialize(serializer);
+        }
+
+        if self.opts & PASSTHROUGH_SUBCLASS == 0 {
+            if is_subclass!(ob_type, Py_TPFLAGS_UNICODE_SUBCLASS) {
+                return StrSubclass::new(self.ptr).serialize(serializer);
+            }
+            if is_subclass!(ob_type, Py_TPFLAGS_LONG_SUBCLASS)
+                && (self.opts & PASSTHROUGH_BIG_INT == 0 || !is_big_int(self.ptr))
+            {
+                return Int::new(self.ptr).serialize(serializer);
+            }
+            if is_subclass!(ob_type, Py_TPFLAGS_LIST_SUBCLASS) {
+                if unlikely!(self.recursion == RECURSION_LIMIT) {
+                    err!(RECURSION_LIMIT_REACHED)
+                }
+                return List::new(
+                    self.ptr,
+                    self.opts,
+                    self.default_calls,
+                    self.recursion,
+                    self.default,
+                )
+                .serialize(serializer);
+            }
+            if is_subclass!(ob_type, Py_TPFLAGS_DICT_SUBCLASS) {
+                if unlikely!(self.recursion == RECURSION_LIMIT) {
+                    err!(RECURSION_LIMIT_REACHED)
+                }
+                return Dict::new(
+                    self.ptr,
+                    self.opts,
+                    self.default_calls,
+                    self.recursion,
+                    self.default,
+                )
+                .serialize(serializer);
+            }
+        }
+
+        if py_is!(ob_type, EXT_TYPE) {
+            return Ext::new(self.ptr).serialize(serializer);
+        }
+
+        if self.opts & PASSTHROUGH_DATACLASS == 0 && pydict_contains!(ob_type, DATACLASS_FIELDS_STR)
+        {
+            if unlikely!(self.recursion == RECURSION_LIMIT) {
+                err!(RECURSION_LIMIT_REACHED)
+            }
+            return Dataclass::new(
+                self.ptr,
+                self.opts,
+                self.default_calls,
+                self.recursion,
+                self.default,
+            )
+            .serialize(serializer);
+        }
+
+        if self.opts & SERIALIZE_PYDANTIC != 0
+            && (pydict_contains!(ob_type, PYDANTIC_FIELDS_STR)
+                || pydict_contains!(ob_type, PYDANTIC2_VALIDATOR_STR))
+        {
+            if unlikely!(self.recursion == RECURSION_LIMIT) {
+                err!(RECURSION_LIMIT_REACHED)
+            }
+            match AttributeDict::new(
+                self.ptr,
+                self.opts,
+                self.default_calls,
+                self.recursion,
+                self.default,
+            ) {
+                Ok(val) => return val.serialize(serializer),
+                Err(AttributeDictError::DictMissing) => err!(PYDANTIC_MUST_HAVE_DICT),
+            };
+        }
+
+        if self.opts & SERIALIZE_NUMPY != 0 {
+            if let Some(numpy_types) = unsafe { NUMPY_TYPES.get_or_init(load_numpy_types) } {
+                let numpy_types_ref = unsafe { numpy_types.as_ref() };
+                if ob_type == numpy_types_ref.bool_ {
+                    return NumpyBool::new(self.ptr).serialize(serializer);
+                }
+                if ob_type == numpy_types_ref.datetime64 {
+                    return NumpyDatetime64::new(self.ptr, self.opts).serialize(serializer);
+                }
+                if ob_type == numpy_types_ref.float16 {
+                    return NumpyFloat16::new(self.ptr).serialize(serializer);
+                }
+                if ob_type == numpy_types_ref.float32 {
+                    return NumpyFloat32::new(self.ptr).serialize(serializer);
+                }
+                if ob_type == numpy_types_ref.float64 {
+                    return NumpyFloat64::new(self.ptr).serialize(serializer);
+                }
+                if ob_type == numpy_types_ref.int8 {
+                    return NumpyInt8::new(self.ptr).serialize(serializer);
+                }
+                if ob_type == numpy_types_ref.int16 {
+                    return NumpyInt16::new(self.ptr).serialize(serializer);
+                }
+                if ob_type == numpy_types_ref.int32 {
+                    return NumpyInt32::new(self.ptr).serialize(serializer);
+                }
+                if ob_type == numpy_types_ref.int64 {
+                    return NumpyInt64::new(self.ptr).serialize(serializer);
+                }
+                if ob_type == numpy_types_ref.uint8 {
+                    return NumpyUint8::new(self.ptr).serialize(serializer);
+                }
+                if ob_type == numpy_types_ref.uint16 {
+                    return NumpyUint16::new(self.ptr).serialize(serializer);
+                }
+                if ob_type == numpy_types_ref.uint32 {
+                    return NumpyUint32::new(self.ptr).serialize(serializer);
+                }
+                if ob_type == numpy_types_ref.uint64 {
+                    return NumpyUint64::new(self.ptr).serialize(serializer);
+                }
+                if ob_type == numpy_types_ref.array {
+                    match NumpyArray::new(self.ptr, self.opts) {
+                        Ok(val) => return val.serialize(serializer),
+                        Err(PyArrayError::Malformed) => err!("numpy array is malformed"),
+                        Err(PyArrayError::NotContiguous)
+                        | Err(PyArrayError::UnsupportedDataType) => {
+                            if self.default.is_none() {
+                                err!("numpy array is not C contiguous; use ndarray.tolist() in default")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Default::new(
+            self.ptr,
+            self.opts,
+            self.default_calls,
+            self.recursion,
+            self.default,
+        )
+        .serialize(serializer)
     }
 }
 
@@ -750,145 +770,174 @@ impl Serialize for PyObject {
     where
         S: Serializer,
     {
-        match self.obtype {
-            ObType::Str => Str::new(self.ptr).serialize(serializer),
-            ObType::Bytes => Bytes::new(self.ptr).serialize(serializer),
-            ObType::StrSubclass => StrSubclass::new(self.ptr).serialize(serializer),
-            ObType::Int => Int::new(self.ptr).serialize(serializer),
-            ObType::None => serializer.serialize_unit(),
-            ObType::Float => serializer.serialize_f64(ffi!(PyFloat_AS_DOUBLE(self.ptr))),
-            ObType::Bool => serializer.serialize_bool(unsafe { self.ptr == TRUE }),
-            ObType::Datetime => match DateTime::new(self.ptr, self.opts) {
-                Ok(val) => val.serialize(serializer),
-                Err(err) => err!(err),
-            },
-            ObType::Date => Date::new(self.ptr).serialize(serializer),
-            ObType::Time => match Time::new(self.ptr, self.opts) {
-                Ok(val) => val.serialize(serializer),
-                Err(err) => err!(err),
-            },
-            ObType::Uuid => UUID::new(self.ptr).serialize(serializer),
-            ObType::Dict => {
-                if unlikely!(self.recursion == RECURSION_LIMIT) {
-                    err!(RECURSION_LIMIT_REACHED)
-                }
-                Dict::new(
-                    self.ptr,
-                    self.opts,
-                    self.default_calls,
-                    self.recursion,
-                    self.default,
-                )
-                .serialize(serializer)
+        let ob_type = ob_type!(self.ptr);
+        if py_is!(ob_type, STR_TYPE) {
+            Str::new(self.ptr).serialize(serializer)
+        } else if py_is!(ob_type, BYTES_TYPE) {
+            Bytes::new(self.ptr).serialize(serializer)
+        } else if py_is!(ob_type, INT_TYPE)
+            && (self.opts & PASSTHROUGH_BIG_INT == 0 || !is_big_int(self.ptr))
+        {
+            Int::new(self.ptr).serialize(serializer)
+        } else if py_is!(ob_type, BOOL_TYPE) {
+            serializer.serialize_bool(unsafe { self.ptr == TRUE })
+        } else if py_is!(self.ptr, NONE) {
+            serializer.serialize_unit()
+        } else if py_is!(ob_type, FLOAT_TYPE) {
+            serializer.serialize_f64(ffi!(PyFloat_AS_DOUBLE(self.ptr)))
+        } else if py_is!(ob_type, LIST_TYPE) {
+            if unlikely!(self.recursion == RECURSION_LIMIT) {
+                err!(RECURSION_LIMIT_REACHED)
             }
-            ObType::List => {
-                if unlikely!(self.recursion == RECURSION_LIMIT) {
-                    err!(RECURSION_LIMIT_REACHED)
-                }
-                List::new(
-                    self.ptr,
-                    self.opts,
-                    self.default_calls,
-                    self.recursion,
-                    self.default,
-                )
-                .serialize(serializer)
-            }
-            ObType::Tuple => {
-                if unlikely!(self.recursion == RECURSION_LIMIT) {
-                    err!(RECURSION_LIMIT_REACHED)
-                }
-                Tuple::new(
-                    self.ptr,
-                    self.opts,
-                    self.default_calls,
-                    self.recursion,
-                    self.default,
-                )
-                .serialize(serializer)
-            }
-            ObType::Dataclass => {
-                if unlikely!(self.recursion == RECURSION_LIMIT) {
-                    err!(RECURSION_LIMIT_REACHED)
-                }
-                Dataclass::new(
-                    self.ptr,
-                    self.opts,
-                    self.default_calls,
-                    self.recursion,
-                    self.default,
-                )
-                .serialize(serializer)
-            }
-            ObType::Pydantic => {
-                if unlikely!(self.recursion == RECURSION_LIMIT) {
-                    err!(RECURSION_LIMIT_REACHED)
-                }
-                match AttributeDict::new(
-                    self.ptr,
-                    self.opts,
-                    self.default_calls,
-                    self.recursion,
-                    self.default,
-                ) {
-                    Ok(val) => val.serialize(serializer),
-                    Err(AttributeDictError::DictMissing) => err!(PYDANTIC_MUST_HAVE_DICT),
-                }
-            }
-            ObType::Enum => {
-                let value = ffi!(PyObject_GetAttr(self.ptr, VALUE_STR));
-                ffi!(Py_DECREF(value));
-                PyObject::new(
-                    value,
-                    self.opts,
-                    self.default_calls,
-                    self.recursion,
-                    self.default,
-                )
-                .serialize(serializer)
-            }
-            ObType::NumpyArray => match NumpyArray::new(self.ptr, self.opts) {
-                Ok(val) => val.serialize(serializer),
-                Err(PyArrayError::Malformed) => err!("numpy array is malformed"),
-                Err(PyArrayError::NotContiguous) | Err(PyArrayError::UnsupportedDataType) => {
-                    if self.default.is_none() {
-                        err!("numpy array is not C contiguous; use ndarray.tolist() in default")
-                    } else {
-                        Default::new(
-                            self.ptr,
-                            self.opts,
-                            self.default_calls,
-                            self.recursion,
-                            self.default,
-                        )
-                        .serialize(serializer)
-                    }
-                }
-            },
-            ObType::NumpyBool => NumpyBool::new(self.ptr).serialize(serializer),
-            ObType::NumpyDatetime64 => {
-                NumpyDatetime64::new(self.ptr, self.opts).serialize(serializer)
-            }
-            ObType::NumpyFloat16 => NumpyFloat16::new(self.ptr).serialize(serializer),
-            ObType::NumpyFloat32 => NumpyFloat32::new(self.ptr).serialize(serializer),
-            ObType::NumpyFloat64 => NumpyFloat64::new(self.ptr).serialize(serializer),
-            ObType::NumpyInt8 => NumpyInt8::new(self.ptr).serialize(serializer),
-            ObType::NumpyInt16 => NumpyInt16::new(self.ptr).serialize(serializer),
-            ObType::NumpyInt32 => NumpyInt32::new(self.ptr).serialize(serializer),
-            ObType::NumpyInt64 => NumpyInt64::new(self.ptr).serialize(serializer),
-            ObType::NumpyUint8 => NumpyUint8::new(self.ptr).serialize(serializer),
-            ObType::NumpyUint16 => NumpyUint16::new(self.ptr).serialize(serializer),
-            ObType::NumpyUint32 => NumpyUint32::new(self.ptr).serialize(serializer),
-            ObType::NumpyUint64 => NumpyUint64::new(self.ptr).serialize(serializer),
-            ObType::Ext => Ext::new(self.ptr).serialize(serializer),
-            ObType::Unknown => Default::new(
+            List::new(
                 self.ptr,
                 self.opts,
                 self.default_calls,
                 self.recursion,
                 self.default,
             )
-            .serialize(serializer),
+            .serialize(serializer)
+        } else if py_is!(ob_type, DICT_TYPE) {
+            if unlikely!(self.recursion == RECURSION_LIMIT) {
+                err!(RECURSION_LIMIT_REACHED)
+            }
+            Dict::new(
+                self.ptr,
+                self.opts,
+                self.default_calls,
+                self.recursion,
+                self.default,
+            )
+            .serialize(serializer)
+        } else {
+            self.serialize_unlikely(serializer)
+        }
+    }
+}
+
+pub struct DictTupleKey {
+    ptr: *mut pyo3::ffi::PyObject,
+    opts: Opt,
+    recursion: u8,
+}
+
+impl DictTupleKey {
+    pub fn new(ptr: *mut pyo3::ffi::PyObject, opts: Opt, recursion: u8) -> Self {
+        DictTupleKey {
+            ptr: ptr,
+            opts: opts,
+            recursion: recursion,
+        }
+    }
+}
+
+impl Serialize for DictTupleKey {
+    #[inline(never)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let len = ffi!(PyTuple_GET_SIZE(self.ptr)) as usize;
+        let mut seq = serializer.serialize_seq(Some(len)).unwrap();
+        for i in 0..len {
+            let item = ffi!(PyTuple_GET_ITEM(self.ptr, i as isize));
+            let value = DictKey::new(item, self.opts, self.recursion + 1);
+            seq.serialize_element(&value)?;
+        }
+        seq.end()
+    }
+}
+
+pub struct DictKey {
+    ptr: *mut pyo3::ffi::PyObject,
+    opts: Opt,
+    recursion: u8,
+}
+
+impl DictKey {
+    pub fn new(ptr: *mut pyo3::ffi::PyObject, opts: Opt, recursion: u8) -> Self {
+        DictKey {
+            ptr: ptr,
+            opts: opts,
+            recursion: recursion,
+        }
+    }
+
+    #[inline(never)]
+    fn serialize_unlikely<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let ob_type = ob_type!(self.ptr);
+
+        if py_is!(ob_type, DATETIME_TYPE) {
+            match DateTime::new(self.ptr, self.opts) {
+                Ok(val) => return val.serialize(serializer),
+                Err(err) => err!(err),
+            }
+        }
+        if py_is!(ob_type, DATE_TYPE) {
+            return Date::new(self.ptr).serialize(serializer);
+        }
+        if py_is!(ob_type, TIME_TYPE) {
+            match Time::new(self.ptr, self.opts) {
+                Ok(val) => return val.serialize(serializer),
+                Err(err) => err!(err),
+            };
+        }
+
+        if py_is!(ob_type, TUPLE_TYPE) {
+            if unlikely!(self.recursion == RECURSION_LIMIT) {
+                err!(RECURSION_LIMIT_REACHED)
+            }
+            return DictTupleKey::new(self.ptr, self.opts, self.recursion).serialize(serializer);
+        }
+
+        if py_is!(ob_type, UUID_TYPE) {
+            return UUID::new(self.ptr).serialize(serializer);
+        }
+
+        if py_is!(ob_type!(ob_type), ENUM_TYPE) {
+            let value = ffi!(PyObject_GetAttr(self.ptr, VALUE_STR));
+            ffi!(Py_DECREF(value));
+            return DictKey::new(value, self.opts, self.recursion).serialize(serializer);
+        }
+
+        if is_subclass!(ob_type, Py_TPFLAGS_UNICODE_SUBCLASS) {
+            return StrSubclass::new(self.ptr).serialize(serializer);
+        }
+        if is_subclass!(ob_type, Py_TPFLAGS_LONG_SUBCLASS) {
+            return Int::new(self.ptr).serialize(serializer);
+        }
+
+        if py_is!(ob_type, EXT_TYPE) {
+            return Ext::new(self.ptr).serialize(serializer);
+        }
+
+        err!("Dict key must a type serializable with OPT_NON_STR_KEYS")
+    }
+}
+
+impl Serialize for DictKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let ob_type = ob_type!(self.ptr);
+        if py_is!(ob_type, STR_TYPE) {
+            Str::new(self.ptr).serialize(serializer)
+        } else if py_is!(ob_type, BYTES_TYPE) {
+            Bytes::new(self.ptr).serialize(serializer)
+        } else if py_is!(ob_type, INT_TYPE) {
+            Int::new(self.ptr).serialize(serializer)
+        } else if py_is!(ob_type, BOOL_TYPE) {
+            serializer.serialize_bool(unsafe { self.ptr == TRUE })
+        } else if py_is!(self.ptr, NONE) {
+            serializer.serialize_unit()
+        } else if py_is!(ob_type, FLOAT_TYPE) {
+            serializer.serialize_f64(ffi!(PyFloat_AS_DOUBLE(self.ptr)))
+        } else {
+            self.serialize_unlikely(serializer)
         }
     }
 }


### PR DESCRIPTION
Incidentally, the new code is faster as it resolves and serializes objects in a single pass.