### PR TITLE
Fix Dependabot updates of python dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
 name = "ormsgpack"
+version = "1.11.0"
 requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -22,7 +23,6 @@ classifiers = [
     "Programming Language :: Rust",
     "Typing :: Typed",
 ]
-dynamic = ["version"]
 authors = [
     {name = "Aviram Hassan", email = "aviramyhassan@gmail.com"},
     {name = "Emanuele Giaquinta", email = "emanuele.giaquinta@gmail.com"},


### PR DESCRIPTION
If the project version is declared as dynamic, "uv lock" cannot use the project metadata and generates the wheel metadata with the build backend. This causes Dependabot to fail when updating the uv lockfile, because it invokes uv in a temporary directory containing only the pyproject.toml file. Work around the issue by specifying the project version statically. See

https://github.com/astral-sh/uv/blob/0.9.4/crates/uv-pypi-types/src/metadata/metadata_resolver.rs#L175 https://github.com/astral-sh/uv/blob/0.9.4/crates/uv-distribution/src/source/mod.rs#L256 https://github.com/dependabot/dependabot-core/blob/v0.341.0/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb#L201