### PR TITLE
Fix inlining of constant expressions

### DIFF
--- a/src/msgpack/bool.rs
+++ b/src/msgpack/bool.rs
@@ -7,6 +7,9 @@ pub fn write_bool<W>(writer: &mut W, value: bool) -> Result<(), std::io::Error>
 where
     W: std::io::Write,
 {
-    let marker = if value { Marker::True } else { Marker::False };
-    writer.write_all(&[marker.into()])
+    if value {
+        writer.write_all(&[Marker::True.into()])
+    } else {
+        writer.write_all(&[Marker::False.into()])
+    }
 }


### PR DESCRIPTION
The use of a non-constant if expression for the marker value in write_bool prevents the compiler from inlining the constant expressions Marker::True.to_u8() and Marker::False.to_u8().