### PR TITLE
Remove bytecount dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
           target: ${{ matrix.target }}
           rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
           manylinux: auto
-          args: --release -i python${{ matrix.python-version }} --features unstable-simd
+          args: --release -i python${{ matrix.python-version }} --features nightly
       - run: uv sync --frozen --no-install-project
       - run: uv pip install ormsgpack --no-index -f target/wheels
       - run: uv run --no-sync pytest
@@ -123,7 +123,7 @@ jobs:
           - platform: 'linux/arm/v7'
             libc: 'musl'
             target: 'armv7-unknown-linux-musleabihf'
-          - maturin_args: '--features unstable-simd'
+          - maturin_args: '--features nightly'
             uv_no_group: ''
           - platform: 'linux/amd64'
             runs-on: 'ubuntu-latest'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,12 +21,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "bytecount"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,7 +84,6 @@ name = "ormsgpack"
 version = "1.12.2"
 dependencies = [
  "ahash",
- "bytecount",
  "chrono",
  "half",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ormsgpack"
 version = "1.12.2"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.88"
 include = [
     "/build.rs",
     "/CHANGELOG.md",
@@ -20,15 +20,10 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-
-# Use SIMD intrinsics. This requires Rust on the nightly channel.
-unstable-simd = [
-    "bytecount/generic-simd",
-]
+nightly = []
 
 [dependencies]
 ahash = { version = "0.8", default-features = false }
-bytecount = { version = "^0.6.9", default-features = false, features = ["runtime-dispatch-simd"] }
 chrono = { version = "0.4.44", default-features = false }
 half = { version = "2.6.0", default-features = false }
 itoa = { version = "1", default-features = false }

--- a/src/ffi/cpython/unicode.rs
+++ b/src/ffi/cpython/unicode.rs
@@ -3,6 +3,7 @@
 #[cfg(unicode_state)]
 use crate::ffi::impl_::unicode_state::*;
 use crate::ffi::unicode::*;
+use crate::str::count_chars;
 use pyo3::ffi::*;
 
 // see unicodeobject.h for documentation
@@ -11,7 +12,7 @@ pub fn unicode_from_str(buf: &str) -> *mut PyObject {
     if buf.is_empty() {
         unsafe { PyUnicode_New(0, 0) }
     } else {
-        let num_chars = bytecount::num_chars(buf.as_bytes());
+        let num_chars = count_chars(buf.as_bytes());
         if buf.len() == num_chars {
             pyunicode_ascii(buf)
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
-#![cfg_attr(feature = "unstable-simd", feature(core_intrinsics))]
+#![cfg_attr(feature = "nightly", feature(core_intrinsics))]
 #![allow(internal_features)]
 #![allow(unused_unsafe)]
 #![allow(clippy::missing_safety_doc)]
@@ -23,6 +23,7 @@ mod msgpack;
 mod opt;
 mod serialize;
 mod state;
+mod str;
 
 use crate::ffi::*;
 use pyo3::ffi::*;

--- a/src/str/aarch64/mod.rs
+++ b/src/str/aarch64/mod.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+mod neon;
+
+pub fn count_chars(bytes: &[u8]) -> usize {
+    let len = bytes.len();
+
+    if len >= 16 {
+        return unsafe { neon::count_chars(bytes) };
+    }
+
+    super::count_chars_scalar(bytes)
+}

--- a/src/str/aarch64/neon.rs
+++ b/src/str/aarch64/neon.rs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+#[rustfmt::skip]
+use std::arch::aarch64::{
+    uint8x16_t,
+    vaddlvq_u8,
+    vandq_u8,
+    vcgtq_s8,
+    vdupq_n_s8,
+    vdupq_n_u8,
+    vld1q_u8,
+    vld1q_u8_x4,
+    vreinterpretq_s8_u8,
+    vsubq_u8,
+};
+
+pub struct U8x16(uint8x16_t);
+
+impl U8x16 {
+    pub const LEN: usize = 16;
+
+    #[target_feature(enable = "neon")]
+    #[inline]
+    pub fn from_array(array: &[u8; 16]) -> Self {
+        unsafe { Self(vld1q_u8(array.as_ptr())) }
+    }
+
+    #[target_feature(enable = "neon")]
+    #[inline]
+    pub fn splat0() -> Self {
+        Self(vdupq_n_u8(0))
+    }
+
+    #[target_feature(enable = "neon")]
+    #[inline]
+    pub fn and(&self, other: &Self) -> Self {
+        Self(vandq_u8(self.0, other.0))
+    }
+
+    #[target_feature(enable = "neon")]
+    #[inline]
+    pub fn sub(&self, other: &Self) -> Self {
+        Self(vsubq_u8(self.0, other.0))
+    }
+
+    #[target_feature(enable = "neon")]
+    #[inline]
+    pub fn mask_utf8_continuation_bytes(&self) -> Self {
+        let v = vdupq_n_s8(-64);
+        Self(vcgtq_s8(v, vreinterpretq_s8_u8(self.0)))
+    }
+
+    #[target_feature(enable = "neon")]
+    #[inline]
+    pub fn reduce_sum(&self) -> usize {
+        vaddlvq_u8(self.0).into()
+    }
+}
+
+pub struct U8x64(uint8x16_t, uint8x16_t, uint8x16_t, uint8x16_t);
+
+impl U8x64 {
+    pub const LEN: usize = 64;
+
+    #[target_feature(enable = "neon")]
+    #[inline]
+    pub fn from_array(array: &[u8; 64]) -> Self {
+        unsafe {
+            let v = vld1q_u8_x4(array.as_ptr());
+            Self(v.0, v.1, v.2, v.3)
+        }
+    }
+
+    #[target_feature(enable = "neon")]
+    #[inline]
+    pub fn splat0() -> Self {
+        let v = vdupq_n_u8(0);
+        Self(v, v, v, v)
+    }
+
+    #[target_feature(enable = "neon")]
+    #[inline]
+    pub fn sub(&self, other: &Self) -> Self {
+        Self(
+            vsubq_u8(self.0, other.0),
+            vsubq_u8(self.1, other.1),
+            vsubq_u8(self.2, other.2),
+            vsubq_u8(self.3, other.3),
+        )
+    }
+
+    #[target_feature(enable = "neon")]
+    #[inline]
+    pub fn mask_utf8_continuation_bytes(&self) -> Self {
+        let v = vdupq_n_s8(-64);
+        Self(
+            vcgtq_s8(v, vreinterpretq_s8_u8(self.0)),
+            vcgtq_s8(v, vreinterpretq_s8_u8(self.1)),
+            vcgtq_s8(v, vreinterpretq_s8_u8(self.2)),
+            vcgtq_s8(v, vreinterpretq_s8_u8(self.3)),
+        )
+    }
+
+    #[target_feature(enable = "neon")]
+    #[inline]
+    pub fn reduce_sum(&self) -> usize {
+        (vaddlvq_u8(self.0) + vaddlvq_u8(self.1) + vaddlvq_u8(self.2) + vaddlvq_u8(self.3)).into()
+    }
+}
+
+define_count_chars!(U8x64, U8x16, #[target_feature(enable = "neon")]);

--- a/src/str/mod.rs
+++ b/src/str/mod.rs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+macro_rules! define_count_chars {
+    ($T1:ty, $T2:ty, $(#[$attrs:meta])*) => {
+        $(#[$attrs])*
+        pub fn count_chars(bytes: &[u8]) -> usize {
+            const N1: usize = <$T1>::LEN;
+            const N2: usize = <$T2>::LEN;
+            let mut count = 0;
+            let (chunks, remainder) = bytes.as_chunks::<N1>();
+
+            for chunk_batch in chunks.chunks(255) {
+                let mut count_vec = <$T1>::splat0();
+                for chunk in chunk_batch {
+                    let vec = <$T1>::from_array(chunk);
+                    count_vec = count_vec.sub(&vec.mask_utf8_continuation_bytes());
+                }
+                count += count_vec.reduce_sum();
+            }
+
+            if !remainder.is_empty() {
+                let mut count_vec = <$T2>::splat0();
+                let (chunks, remainder) = remainder.as_chunks::<N2>();
+
+                for chunk in chunks {
+                    let vec = <$T2>::from_array(chunk);
+                    count_vec = count_vec.sub(&vec.mask_utf8_continuation_bytes());
+                }
+
+                if !remainder.is_empty() {
+                    const MASK: [u8; N2 * 2] = const {
+                        let mut mask = [0u8; N2 * 2];
+                        let mut i = N2;
+                        while i < N2 * 2 {
+                            mask[i] = 0xff;
+                            i += 1;
+                        }
+                        mask
+                    };
+                    let chunk = bytes.last_chunk::<N2>().unwrap();
+                    let vec = <$T2>::from_array(chunk);
+                    let mask_chunk = MASK[remainder.len()..].first_chunk::<N2>().unwrap();
+                    let mask_vec = <$T2>::from_array(mask_chunk);
+                    count_vec = count_vec.sub(&vec.mask_utf8_continuation_bytes().and(&mask_vec));
+                }
+
+                count += count_vec.reduce_sum();
+            }
+
+            bytes.len() - count
+        }
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+mod aarch64;
+
+#[cfg(target_arch = "aarch64")]
+pub use aarch64::count_chars;
+
+#[cfg(target_arch = "x86_64")]
+mod x86_64;
+
+#[cfg(target_arch = "x86_64")]
+pub use x86_64::count_chars;
+
+#[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+pub use count_chars_scalar as count_chars;
+
+#[inline]
+fn is_utf8_non_continuation_byte(byte: u8) -> bool {
+    (byte as i8) >= -64
+}
+
+#[inline]
+fn mask_utf8_non_continuation_bytes(v: u64) -> u64 {
+    ((!v >> 7) | (v >> 6)) & 0x0101010101010101
+}
+
+#[inline]
+fn reduce_sum(v: u64) -> usize {
+    const MASK: u64 = 0x00ff00ff00ff00ff;
+    let sums = (v & MASK) + ((v >> 8) & MASK);
+    (sums.wrapping_mul(0x0001000100010001) >> 48) as usize
+}
+
+#[inline]
+pub fn count_chars_scalar(bytes: &[u8]) -> usize {
+    let mut count = 0;
+    let (chunks, remainder) = bytes.as_chunks::<8>();
+
+    for chunk_batch in chunks.chunks(255) {
+        let mut count_vec = 0;
+        for chunk in chunk_batch {
+            let vec = u64::from_ne_bytes(*chunk);
+            count_vec += mask_utf8_non_continuation_bytes(vec);
+        }
+        count += reduce_sum(count_vec);
+    }
+
+    remainder
+        .iter()
+        .filter(|&&byte| is_utf8_non_continuation_byte(byte))
+        .count()
+        + count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_count_chars() {
+        let p = "aα∞🚀";
+        #[rustfmt::skip]
+        let lengths = [
+            8 + 2,
+            16 + 4,
+            32 + 8,
+            64 + 6,
+            64 * (255 + 1) + 32 + 4,
+        ];
+        for len in lengths {
+            let s = p.repeat(len / p.len());
+            assert_eq!(count_chars(s.as_bytes()), s.chars().count());
+        }
+    }
+}

--- a/src/str/x86_64/avx2.rs
+++ b/src/str/x86_64/avx2.rs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+#[rustfmt::skip]
+use std::arch::x86_64::{
+    __m256i,
+    _mm256_and_si256,
+    _mm256_castsi256_si128,
+    _mm256_cmpgt_epi8,
+    _mm256_extracti128_si256,
+    _mm256_loadu_si256,
+    _mm256_sad_epu8,
+    _mm256_set1_epi8,
+    _mm256_setzero_si256,
+    _mm256_sub_epi8,
+    _mm_add_epi64,
+    _mm_cvtsi128_si64,
+    _mm_srli_si128,
+};
+
+#[target_feature(enable = "avx2")]
+#[inline]
+fn reduce_sum(a: __m256i) -> usize {
+    let sums4 = _mm256_sad_epu8(a, _mm256_setzero_si256());
+    let sums2 = _mm_add_epi64(
+        _mm256_castsi256_si128(sums4),
+        _mm256_extracti128_si256(sums4, 1),
+    );
+    let sum = _mm_add_epi64(sums2, _mm_srli_si128(sums2, 8));
+    _mm_cvtsi128_si64(sum) as usize
+}
+
+pub struct U8x32(__m256i);
+
+impl U8x32 {
+    pub const LEN: usize = 32;
+
+    #[target_feature(enable = "avx2")]
+    #[inline]
+    pub fn from_array(array: &[u8; 32]) -> Self {
+        unsafe {
+            let ptr = array.as_ptr().cast::<__m256i>();
+            Self(_mm256_loadu_si256(ptr))
+        }
+    }
+
+    #[target_feature(enable = "avx2")]
+    #[inline]
+    pub fn splat0() -> Self {
+        Self(_mm256_setzero_si256())
+    }
+
+    #[target_feature(enable = "avx2")]
+    #[inline]
+    pub fn and(&self, other: &Self) -> Self {
+        Self(_mm256_and_si256(self.0, other.0))
+    }
+
+    #[target_feature(enable = "avx2")]
+    #[inline]
+    pub fn sub(&self, other: &Self) -> Self {
+        Self(_mm256_sub_epi8(self.0, other.0))
+    }
+
+    #[target_feature(enable = "avx2")]
+    #[inline]
+    pub fn mask_utf8_continuation_bytes(&self) -> Self {
+        let v = _mm256_set1_epi8(-64);
+        Self(_mm256_cmpgt_epi8(v, self.0))
+    }
+
+    #[target_feature(enable = "avx2")]
+    #[inline]
+    pub fn reduce_sum(&self) -> usize {
+        reduce_sum(self.0)
+    }
+}
+
+pub struct U8x64(__m256i, __m256i);
+
+impl U8x64 {
+    pub const LEN: usize = 64;
+
+    #[target_feature(enable = "avx2")]
+    #[inline]
+    pub fn from_array(array: &[u8; 64]) -> Self {
+        unsafe {
+            let ptr = array.as_ptr().cast::<__m256i>();
+            Self(_mm256_loadu_si256(ptr), _mm256_loadu_si256(ptr.add(1)))
+        }
+    }
+
+    #[target_feature(enable = "avx2")]
+    #[inline]
+    pub fn splat0() -> Self {
+        let v = _mm256_setzero_si256();
+        Self(v, v)
+    }
+
+    #[target_feature(enable = "avx2")]
+    #[inline]
+    pub fn sub(&self, other: &Self) -> Self {
+        Self(
+            _mm256_sub_epi8(self.0, other.0),
+            _mm256_sub_epi8(self.1, other.1),
+        )
+    }
+
+    #[target_feature(enable = "avx2")]
+    #[inline]
+    pub fn mask_utf8_continuation_bytes(&self) -> Self {
+        let v = _mm256_set1_epi8(-64);
+        Self(_mm256_cmpgt_epi8(v, self.0), _mm256_cmpgt_epi8(v, self.1))
+    }
+
+    #[target_feature(enable = "avx2")]
+    #[inline]
+    pub fn reduce_sum(&self) -> usize {
+        reduce_sum(self.0) + reduce_sum(self.1)
+    }
+}
+
+define_count_chars!(U8x64, U8x32, #[target_feature(enable = "avx2")]);

--- a/src/str/x86_64/mod.rs
+++ b/src/str/x86_64/mod.rs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+mod avx2;
+mod sse2;
+
+pub fn count_chars(bytes: &[u8]) -> usize {
+    let len = bytes.len();
+
+    if len >= 32 && is_x86_feature_detected!("avx2") {
+        return unsafe { avx2::count_chars(bytes) };
+    }
+
+    if len >= 16 {
+        return unsafe { sse2::count_chars(bytes) };
+    }
+
+    super::count_chars_scalar(bytes)
+}

--- a/src/str/x86_64/sse2.rs
+++ b/src/str/x86_64/sse2.rs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+#[rustfmt::skip]
+use std::arch::x86_64::{
+    __m128i,
+    _mm_add_epi64,
+    _mm_and_si128,
+    _mm_cmpgt_epi8,
+    _mm_cvtsi128_si64,
+    _mm_loadu_si128,
+    _mm_sad_epu8,
+    _mm_set1_epi8,
+    _mm_setzero_si128,
+    _mm_srli_si128,
+    _mm_sub_epi8,
+};
+
+#[target_feature(enable = "sse2")]
+#[inline]
+fn reduce_sum(a: __m128i) -> usize {
+    let sums = _mm_sad_epu8(a, _mm_setzero_si128());
+    let sum = _mm_add_epi64(sums, _mm_srli_si128(sums, 8));
+    _mm_cvtsi128_si64(sum) as usize
+}
+
+pub struct U8x16(__m128i);
+
+impl U8x16 {
+    pub const LEN: usize = 16;
+
+    #[target_feature(enable = "sse2")]
+    #[inline]
+    pub fn from_array(array: &[u8; 16]) -> Self {
+        unsafe {
+            let ptr = array.as_ptr().cast::<__m128i>();
+            Self(_mm_loadu_si128(ptr))
+        }
+    }
+
+    #[target_feature(enable = "sse2")]
+    #[inline]
+    pub fn splat0() -> Self {
+        Self(_mm_setzero_si128())
+    }
+
+    #[target_feature(enable = "sse2")]
+    #[inline]
+    pub fn and(&self, other: &Self) -> Self {
+        Self(_mm_and_si128(self.0, other.0))
+    }
+
+    #[target_feature(enable = "sse2")]
+    #[inline]
+    pub fn sub(&self, other: &Self) -> Self {
+        Self(_mm_sub_epi8(self.0, other.0))
+    }
+
+    #[target_feature(enable = "sse2")]
+    #[inline]
+    pub fn mask_utf8_continuation_bytes(&self) -> Self {
+        let v = _mm_set1_epi8(-64);
+        Self(_mm_cmpgt_epi8(v, self.0))
+    }
+
+    #[target_feature(enable = "sse2")]
+    #[inline]
+    pub fn reduce_sum(&self) -> usize {
+        reduce_sum(self.0)
+    }
+}
+
+pub struct U8x64(__m128i, __m128i, __m128i, __m128i);
+
+impl U8x64 {
+    pub const LEN: usize = 64;
+
+    #[target_feature(enable = "sse2")]
+    #[inline]
+    pub fn from_array(array: &[u8; 64]) -> Self {
+        unsafe {
+            let ptr = array.as_ptr().cast::<__m128i>();
+            Self(
+                _mm_loadu_si128(ptr),
+                _mm_loadu_si128(ptr.add(1)),
+                _mm_loadu_si128(ptr.add(2)),
+                _mm_loadu_si128(ptr.add(3)),
+            )
+        }
+    }
+
+    #[target_feature(enable = "sse2")]
+    #[inline]
+    pub fn splat0() -> Self {
+        let v = _mm_setzero_si128();
+        Self(v, v, v, v)
+    }
+
+    #[target_feature(enable = "sse2")]
+    #[inline]
+    pub fn sub(&self, other: &Self) -> Self {
+        Self(
+            _mm_sub_epi8(self.0, other.0),
+            _mm_sub_epi8(self.1, other.1),
+            _mm_sub_epi8(self.2, other.2),
+            _mm_sub_epi8(self.3, other.3),
+        )
+    }
+
+    #[target_feature(enable = "sse2")]
+    #[inline]
+    pub fn mask_utf8_continuation_bytes(&self) -> Self {
+        let v = _mm_set1_epi8(-64);
+        Self(
+            _mm_cmpgt_epi8(v, self.0),
+            _mm_cmpgt_epi8(v, self.1),
+            _mm_cmpgt_epi8(v, self.2),
+            _mm_cmpgt_epi8(v, self.3),
+        )
+    }
+
+    #[target_feature(enable = "sse2")]
+    #[inline]
+    pub fn reduce_sum(&self) -> usize {
+        reduce_sum(self.0) + reduce_sum(self.1) + reduce_sum(self.2) + reduce_sum(self.3)
+    }
+}
+
+define_count_chars!(U8x64, U8x16, #[target_feature(enable = "sse2")]);

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,14 +6,14 @@ macro_rules! ob_type {
     };
 }
 
-#[cfg(feature = "unstable-simd")]
+#[cfg(feature = "nightly")]
 macro_rules! unlikely {
     ($exp:expr) => {
         core::intrinsics::unlikely($exp)
     };
 }
 
-#[cfg(not(feature = "unstable-simd"))]
+#[cfg(not(feature = "nightly"))]
 macro_rules! unlikely {
     ($exp:expr) => {
         $exp


### PR DESCRIPTION
This commit adds an implementation of the standard SIMD algorithm to count the number of code points in a UTF-8 sequence. The implementation uses a thin SIMD abstraction layer in order to have a portable function definition and is as fast as bytecount::num_chars, based on benchmarks performed on arm64 and x86_64.

The motivation for this change is that the bytecount crate is not maintained and lacks support for AVX-512. Ideally this functionality would be provided by the simdutf8 crate, analogously to the simdutf C++ library.